### PR TITLE
Enable drag and drop to open files

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -275,12 +275,15 @@ void PointViewerMainWindow::dropEvent(QDropEvent *event)
     QList<QUrl> urls = event->mimeData()->urls();
     if (urls.isEmpty())
         return;
-
-    QStringList DroppedFiles;
-    for( int i=0; i<urls.size(); i++ ) 
-			DroppedFiles << urls[i].toLocalFile();
-
-    m_pointView->loadFiles(DroppedFiles);
+    QStringList droppedFiles;
+    for( int i = 0; i < urls.size(); ++i ) 
+    {
+         if( urls[i].isLocalFile() )
+         {
+             droppedFiles << urls[i].toLocalFile();
+         }
+    }
+    m_pointView->loadFiles(droppedFiles);
 }
 
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -68,8 +68,8 @@ class PointViewerMainWindow : public QMainWindow
 
     protected:
         void keyReleaseEvent(QKeyEvent* event);
-	void dragEnterEvent(QDragEnterEvent *event);
-	void dropEvent(QDropEvent *event);
+        void dragEnterEvent(QDragEnterEvent *event);
+        void dropEvent(QDropEvent *event);
     
     private slots:
         void openFiles();


### PR DESCRIPTION
Added the QT event handler to allow either a single file or multiple
files to be opened by drag and drop onto displaz window.

Tested on Ubuntu 12.04 64-bit.
