### PR TITLE
Resolve Intel GPU rendering artifacts

### DIFF
--- a/src/view3d.cpp
+++ b/src/view3d.cpp
@@ -224,7 +224,9 @@ std::unique_ptr<QGLFramebufferObject> View3D::allocIncrementalFramebuffer(int w,
     const QGLFormat fmt = context()->format();
     QGLFramebufferObjectFormat fboFmt;
     fboFmt.setAttachment(QGLFramebufferObject::Depth);
-    fboFmt.setSamples(fmt.samples());
+    // Intel HD 3000 driver doesn't like the multisampling mode that Qt 4.8 uses
+    // for samples==1, so work around it by forcing 0, if possible
+    fboFmt.setSamples(fmt.samples() > 1 ? fmt.samples() : 0);
     //fboFmt.setTextureTarget();
     return std::unique_ptr<QGLFramebufferObject>(
         new QGLFramebufferObject(w, h, fboFmt));


### PR DESCRIPTION
Resolve Issue #50 

-----------------

https://github.com/c42f/displaz/issues/50

Qt 4.8 uses the multisampling codepath for samples==1,
which the Intel OpenGL driver does not seem to like.
Forcing samples=0 as a workaround.