### PR TITLE
Resolve debug-mode Qt assertion converning invalid range for Geometry…

### DIFF
--- a/src/geometrycollection.cpp
+++ b/src/geometrycollection.cpp
@@ -13,9 +13,12 @@ GeometryCollection::GeometryCollection(QObject* parent)
 
 void GeometryCollection::clear()
 {
-    emit beginRemoveRows(QModelIndex(), 0, (int)m_geometries.size()-1);
-    m_geometries.clear();
-    emit endRemoveRows();
+    if (m_geometries.size())
+    {
+        emit beginRemoveRows(QModelIndex(), 0, (int)m_geometries.size()-1);
+        m_geometries.clear();
+        emit endRemoveRows();
+    }
 }
 
 


### PR DESCRIPTION
I came across an assertion with a debug-enabled Qt 4.8
The value of "last" was being passed -1 for empty container.