### PR TITLE
Intel HD 3000 OpenGL driver fails to attach depth buffer to FBO, add …

### DIFF
--- a/src/view3d.cpp
+++ b/src/view3d.cpp
@@ -228,8 +228,11 @@ std::unique_ptr<QGLFramebufferObject> View3D::allocIncrementalFramebuffer(int w,
     // for samples==1, so work around it by forcing 0, if possible
     fboFmt.setSamples(fmt.samples() > 1 ? fmt.samples() : 0);
     //fboFmt.setTextureTarget();
-    return std::unique_ptr<QGLFramebufferObject>(
-        new QGLFramebufferObject(w, h, fboFmt));
+    std::unique_ptr<QGLFramebufferObject> fbo;
+    fbo.reset(new QGLFramebufferObject(w, h, fboFmt));
+    if (fbo.get() && fbo->attachment()==QGLFramebufferObject::NoAttachment)
+        g_logger.error("%s", "Failed to attach FBO depth buffer.");
+    return fbo;
 }
 
 


### PR DESCRIPTION
Check for failure to make an FBO attachment and log an error message, rather than continuing silently.  A workaround for the Intel multi-sampling is in a separate pull request.