### PR TITLE
Update to travis ci to build OS X version as well.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,10 @@ script:
     - cd ..
 
 install:
-    - sudo apt-get install wget git g++ cmake libqt4-dev libqt4-opengl-dev python-docutils
-    - wget https://launchpad.net/~kalakris/+archive/ubuntu/cmake/+build/4892863/+files/cmake_2.8.11.2-1ubuntu2~precise1_amd64.deb
-    - wget https://launchpad.net/~kalakris/+archive/ubuntu/cmake/+files/cmake-data_2.8.11.2-1ubuntu2~precise1_all.deb
-    - sudo dpkg -i cmake_2.8.11.2-1ubuntu2~precise1_amd64.deb cmake-data_2.8.11.2-1ubuntu2~precise1_all.deb
+    - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install wget git g++ cmake libqt4-dev libqt4-opengl-dev python-docutils; fi
+    - if [ "$TRAVIS_OS_NAME" == "linux" ]; then wget https://launchpad.net/~kalakris/+archive/ubuntu/cmake/+build/4892863/+files/cmake_2.8.11.2-1ubuntu2~precise1_amd64.deb; fi
+    - if [ "$TRAVIS_OS_NAME" == "linux" ]; then wget https://launchpad.net/~kalakris/+archive/ubuntu/cmake/+files/cmake-data_2.8.11.2-1ubuntu2~precise1_all.deb; fi
+    - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo dpkg -i cmake_2.8.11.2-1ubuntu2~precise1_amd64.deb cmake-data_2.8.11.2-1ubuntu2~precise1_all.deb; fi
 
 matrix:
     exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,43 @@
 language: cpp
 
 os:
-  - linux
-  - osx
+    - linux
+    - osx
 
 compiler:
-  - gcc
-  - clang
+    - gcc
+    - clang
 
 branches:
   only:
     - master
     - travis-osx
 
-before_script:
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install git qt4; fi
+before_install:
+    - if [ "$TRAVIS_OS_NAME" == "linux" ]; then wget https://launchpad.net/~kalakris/+archive/ubuntu/cmake/+build/4892863/+files/cmake_2.8.11.2-1ubuntu2~precise1_amd64.deb; fi
+    - if [ "$TRAVIS_OS_NAME" == "linux" ]; then wget https://launchpad.net/~kalakris/+archive/ubuntu/cmake/+files/cmake-data_2.8.11.2-1ubuntu2~precise1_all.deb; fi
+    - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
 
-script:
-    #- cmake --version
+install:
+    - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install wget git g++ cmake libqt4-dev libqt4-opengl-dev python-docutils; fi
+    - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo dpkg -i cmake_2.8.11.2-1ubuntu2~precise1_amd64.deb cmake-data_2.8.11.2-1ubuntu2~precise1_all.deb; fi
+    - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install git qt4; fi
+
+before_script:
     # Build external tools
-    #- pwd
     - mkdir build_external
     - cd build_external
     - cmake ../thirdparty/external
     - make -j4
     - cd ..
+
+script:
     # Build displaz
-    #- pwd
     - mkdir build
     - cd build
     - cmake ..
     - make -j4
     - cd ..
-
-install:
-    - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install wget git g++ cmake libqt4-dev libqt4-opengl-dev python-docutils; fi
-    - if [ "$TRAVIS_OS_NAME" == "linux" ]; then wget https://launchpad.net/~kalakris/+archive/ubuntu/cmake/+build/4892863/+files/cmake_2.8.11.2-1ubuntu2~precise1_amd64.deb; fi
-    - if [ "$TRAVIS_OS_NAME" == "linux" ]; then wget https://launchpad.net/~kalakris/+archive/ubuntu/cmake/+files/cmake-data_2.8.11.2-1ubuntu2~precise1_all.deb; fi
-    - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo dpkg -i cmake_2.8.11.2-1ubuntu2~precise1_amd64.deb cmake-data_2.8.11.2-1ubuntu2~precise1_all.deb; fi
 
 matrix:
     exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,17 @@
 language: cpp
+
+os:
+  - linux
+  - osx
+
+compiler:
+  - gcc
+  - clang
+
+branches:
+  only:
+    - master
+
 script:
 #- cmake --version
 # Build external tools
@@ -20,3 +33,14 @@ install:
  - wget https://launchpad.net/~kalakris/+archive/ubuntu/cmake/+build/4892863/+files/cmake_2.8.11.2-1ubuntu2~precise1_amd64.deb
  - wget https://launchpad.net/~kalakris/+archive/ubuntu/cmake/+files/cmake-data_2.8.11.2-1ubuntu2~precise1_all.deb
  - sudo dpkg -i cmake_2.8.11.2-1ubuntu2~precise1_amd64.deb cmake-data_2.8.11.2-1ubuntu2~precise1_all.deb
+
+matrix:
+    exclude:
+      # Only check gcc on linux and clang on OS X
+      - os: linux
+        compiler: clang
+      - os: osx
+        compiler: gcc
+    allow_failures:
+     # For now ignore every OS X build issues
+     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,11 @@ script:
 
 matrix:
     exclude:
-      # Only check gcc on linux and clang on OS X
-      - os: linux
-        compiler: clang
-      - os: osx
-        compiler: gcc
+        # Only check gcc on linux and clang on OS X
+        - os: linux
+            compiler: clang
+        - os: osx
+            compiler: gcc
     allow_failures:
-     # For now ignore every OS X build issues
-     - os: osx
+        # For now ignore every OS X build issues
+        - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,28 +11,34 @@ compiler:
 branches:
   only:
     - master
+    - travis-osx
+
+before_script:
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install git qt4; fi
 
 script:
-#- cmake --version
-# Build external tools
-#- pwd
-- mkdir build_external
-- cd build_external
-- cmake ../thirdparty/external
-- make -j4
-- cd ..
-# Build displaz
-#- pwd
-- mkdir build
-- cd build
-- cmake ..
-- make -j4
-- cd ..
+    #- cmake --version
+    # Build external tools
+    #- pwd
+    - mkdir build_external
+    - cd build_external
+    - cmake ../thirdparty/external
+    - make -j4
+    - cd ..
+    # Build displaz
+    #- pwd
+    - mkdir build
+    - cd build
+    - cmake ..
+    - make -j4
+    - cd ..
+
 install:
- - sudo apt-get install wget git g++ cmake libqt4-dev libqt4-opengl-dev python-docutils
- - wget https://launchpad.net/~kalakris/+archive/ubuntu/cmake/+build/4892863/+files/cmake_2.8.11.2-1ubuntu2~precise1_amd64.deb
- - wget https://launchpad.net/~kalakris/+archive/ubuntu/cmake/+files/cmake-data_2.8.11.2-1ubuntu2~precise1_all.deb
- - sudo dpkg -i cmake_2.8.11.2-1ubuntu2~precise1_amd64.deb cmake-data_2.8.11.2-1ubuntu2~precise1_all.deb
+    - sudo apt-get install wget git g++ cmake libqt4-dev libqt4-opengl-dev python-docutils
+    - wget https://launchpad.net/~kalakris/+archive/ubuntu/cmake/+build/4892863/+files/cmake_2.8.11.2-1ubuntu2~precise1_amd64.deb
+    - wget https://launchpad.net/~kalakris/+archive/ubuntu/cmake/+files/cmake-data_2.8.11.2-1ubuntu2~precise1_all.deb
+    - sudo dpkg -i cmake_2.8.11.2-1ubuntu2~precise1_amd64.deb cmake-data_2.8.11.2-1ubuntu2~precise1_all.deb
 
 matrix:
     exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,9 @@ matrix:
     exclude:
         # Only check gcc on linux and clang on OS X
         - os: linux
-            compiler: clang
+          compiler: clang
         - os: osx
-            compiler: gcc
+          compiler: gcc
     allow_failures:
         # For now ignore every OS X build issues
         - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,12 @@ compiler:
     - gcc
     - clang
 
-branches:
-  only:
-    - master
-    - travis-osx
+# either whitelist or blacklist branches
+# branches:
+#     only:
+#         - master
+#     except:
+#         - experimental
 
 before_install:
     - if [ "$TRAVIS_OS_NAME" == "linux" ]; then wget https://launchpad.net/~kalakris/+archive/ubuntu/cmake/+build/4892863/+files/cmake_2.8.11.2-1ubuntu2~precise1_amd64.deb; fi


### PR DESCRIPTION
As discussed in issue #76 I added support for OS X build testing on travis (failures under OS X are allowed though). I also tested a version that actually compiles CMake 2.8.12.2, but this makes the whole build process take much longer.