### PR TITLE
WIP: Improved binding API for plotting in julia

### DIFF
--- a/bindings/julia/Displaz.jl
+++ b/bindings/julia/Displaz.jl
@@ -153,6 +153,11 @@ column vector :-(  Can we have a set of consistent broadcasting rules for this?
 It seems like the case of a 3x3 matrix will always be ambiguous if we try
 to guess what the user wants.
 
+### Data set attributes
+
+The following attributes can be attached to a dataset on each call to `plot3d`:
+
+  * `label` - A string labeling the data set
 
 ### Vertex attributes
 
@@ -195,7 +200,7 @@ position array into multiple line segments.  Each index in the line break array
 is the initial index of a line segment.
 """
 function plot3d(position; color=[1,1,1], markersize=[0.1], markershape=[0],
-                linebreak=[1], _clear_before_plot=true)
+                label=nothing, linebreak=[1], _clear_before_plot=true)
     nvertices = size(position, 2)
     color = interpret_color(color)
     markershape = interpret_shape(markershape)
@@ -212,7 +217,9 @@ function plot3d(position; color=[1,1,1], markersize=[0.1], markershape=[0],
     markersize = map(Float32,markersize)
     size(color,2) == nvertices || error("color must have same number of rows as position array")
     filename = tempname()*".ply"
+    seriestype = "Points"
     if '-' in markershape # Plot lines
+        seriestype = "Line"
         write_ply_lines(filename, position, color, linebreak)
     else # Plot points
         if length(markersize) == 1
@@ -229,8 +236,11 @@ function plot3d(position; color=[1,1,1], markersize=[0.1], markershape=[0],
                          (:markershape, array_semantic, vec(markershape)'),
                          ))
     end
+    if label === nothing
+        label = "$seriestype [$nvertices vertices]"
+    end
     addopt = _clear_before_plot ? [] : "-add"
-    run(`displaz -background $addopt -shader generic_points.glsl -rmtemp $filename`)
+    run(`displaz -background $addopt -dataname $label -shader generic_points.glsl -rmtemp $filename`)
     nothing
 end
 

--- a/bindings/julia/example.jl
+++ b/bindings/julia/example.jl
@@ -1,16 +1,16 @@
 using Displaz
 
 function example(N)
-    t = linspace(0,1, N)
-    P = (10.+0.2*rand(size(t))).*[exp(5*t).*cos(100*pi*t)  exp(5*t).*sin(100*pi*t)  100*t];
-    C = [t (1 .- t) zeros(t)];
+    t = linspace(0,1, N)'
+    P = (10.+0.2*rand(size(t))) .* vcat(exp(5*t).*cos(100*pi*t),
+                                        exp(5*t).*sin(100*pi*t),
+                                        100*t);
+    C = vcat(t, 1.-t, zeros(t));
     sz  = map(Float32, t)
-    shape = mod(rand(Uint8, N), 6)
-    clf()
-    hold(true)
-    plot(P; color = C)
-    P[:,3] = -P[:,3]
-    plot(P; color = C, markersize = sz, markershape = shape)
+    shape = mod(rand(UInt8, N), 6)
+    plot3d(P, color = C, label="Top series")
+    P[3,:] = -P[3,:]
+    plot3d!(P, color = C, markersize = sz, markershape = shape, label="Bottom series")
 end
 
 example(1_000_000)


### PR DESCRIPTION
Work in progress refactoring of julia bindings for displaz (#82)

@JoshChristie @BuzzVII @PaulBellette - should be much improved, other than figuring out a consistent convention for the shape of vertex attribute arrays which seems to be a pain.  Any ideas for improving the API?

* Rename plot() -> plot3d() to avoid clash with 2D plotting interfaces.

* Rethink orientation of position and other vertex attribute arrays.
  (Now the transpose!)  Unfortunately this still has caveats... can we
  do better?

* Documentation for main plotting interface

* Deprecate hold(), clf(); replace with plot3d/plot3d!
  convention from Plots.jl

* Deprecate plot().  May actually just need to avoid exporting this,
  since one of the main points is to avoid clashing with 2D plotting
  tools.