### PR TITLE
Send initial point shader on displaz command line

### DIFF
--- a/src/guimain.cpp
+++ b/src/guimain.cpp
@@ -43,12 +43,14 @@ int main(int argc, char* argv[])
     std::string lockName;
     std::string lockId;
     std::string socketName;
+    std::string shaderName;
 
     ArgParse::ArgParse ap;
     ap.options(
         "displaz-gui - don't use this directly, use the displaz commandline helper instead)",
         "-instancelock %s %s", &lockName, &lockId, "Single instance lock name and ID to reacquire",
         "-socketname %s", &socketName,             "Local socket name for IPC",
+        "-shader %s",    &shaderName,              "Name of shader file to load on startup",
         NULL
     );
 
@@ -79,7 +81,7 @@ int main(int argc, char* argv[])
     //f.setSampleBuffers(true);
     QGLFormat::setDefaultFormat(f);
 
-    PointViewerMainWindow window(f);
+    PointViewerMainWindow window(f, QString::fromStdString(shaderName));
     InterProcessLock instanceLock(lockName);
     if (!lockId.empty())
         instanceLock.inherit(lockId);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -163,7 +163,9 @@ int main(int argc, char *argv[])
         QStringList args;
         args << "-instancelock" << QString::fromStdString(lockName)
                                 << QString::fromStdString(instanceLock.makeLockId())
-             << "-socketname"   << socketName;
+             << "-socketname"   << socketName
+             << "-shader"       << QString::fromStdString(shaderName);
+
         QString guiExe = QDir(QCoreApplication::applicationDirPath())
                          .absoluteFilePath("displaz-gui");
         if (!QProcess::startDetached(guiExe, args,
@@ -257,16 +259,6 @@ int main(int argc, char *argv[])
     {
         channel->sendMessage("SET_MAX_POINT_COUNT\n" +
                              QByteArray().setNum(maxPointCount));
-    }
-    if (!shaderName.empty() && startedGui)
-    {
-        // Note - only send the OPEN_SHADER command when the GUI is initially
-        // started, since this is probably what you want when using from a
-        // scripting language.
-        // TODO: This shader open behaviour seems a bit inconsistent - figure
-        // out how to make it nicer?
-        channel->sendMessage(QByteArray("OPEN_SHADER\n") +
-                             shaderName.c_str());
     }
 
     if (startedGui && !script)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -38,7 +38,7 @@
 //------------------------------------------------------------------------------
 // PointViewerMainWindow implementation
 
-PointViewerMainWindow::PointViewerMainWindow(const QGLFormat& format)
+PointViewerMainWindow::PointViewerMainWindow(const QGLFormat& format, const QString & pointShader)
     : m_progressBar(0),
     m_pointView(0),
     m_shaderEditor(0),
@@ -178,7 +178,7 @@ PointViewerMainWindow::PointViewerMainWindow(const QGLFormat& format)
 
     //--------------------------------------------------
     // Point viewer
-    m_pointView = new View3D(m_geometries, format, this);
+    m_pointView = new View3D(m_geometries, format, this, pointShader);
     setCentralWidget(m_pointView);
     connect(drawBoundingBoxes, SIGNAL(triggered()),
             m_pointView, SLOT(toggleDrawBoundingBoxes()));
@@ -463,10 +463,6 @@ void PointViewerMainWindow::handleMessage(QByteArray message)
     else if (commandTokens[0] == "SET_MAX_POINT_COUNT")
     {
         m_maxPointCount = commandTokens[1].toLongLong();
-    }
-    else if (commandTokens[0] == "OPEN_SHADER")
-    {
-        openShaderFile(commandTokens[1]);
     }
     else
     {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -34,7 +34,7 @@ class PointViewerMainWindow : public QMainWindow
     Q_OBJECT
 
     public:
-        PointViewerMainWindow(const QGLFormat& format);
+        PointViewerMainWindow(const QGLFormat& format, const QString & pointShader);
 
         /// Hint at an appropriate size
         QSize sizeHint() const;

--- a/src/view3d.cpp
+++ b/src/view3d.cpp
@@ -25,7 +25,8 @@
 #include "util.h"
 
 //------------------------------------------------------------------------------
-View3D::View3D(GeometryCollection* geometries, const QGLFormat& format, QWidget *parent)
+View3D::View3D(GeometryCollection* geometries, const QGLFormat& format, QWidget *parent,
+               const QString initialPointShader)
     : QGLWidget(format, parent),
     m_camera(false, false),
     m_mouseButton(Qt::NoButton),
@@ -38,6 +39,7 @@ View3D::View3D(GeometryCollection* geometries, const QGLFormat& format, QWidget 
     m_drawAxes(true),
     m_drawGrid(false),
     m_badOpenGL(false),
+    m_initialPointShader(initialPointShader),
     m_shaderProgram(),
     m_geometries(geometries),
     m_selectionModel(0),
@@ -90,6 +92,11 @@ View3D::View3D(GeometryCollection* geometries, const QGLFormat& format, QWidget 
     m_incrementalFrameTimer = new QTimer(this);
     m_incrementalFrameTimer->setSingleShot(false);
     connect(m_incrementalFrameTimer, SIGNAL(timeout()), this, SLOT(updateGL()));
+
+    if (m_initialPointShader.isEmpty())
+    {
+        m_initialPointShader = "shaders:las_points.glsl";
+    }
 }
 
 
@@ -304,7 +311,7 @@ void View3D::initializeGL()
     // be initialized with the default shader, but View3D can only compile
     // shaders after it has a valid OpenGL context.
     PointViewerMainWindow * pv_parent = dynamic_cast<PointViewerMainWindow *>(parentWidget());
-    pv_parent->openShaderFile("shaders:las_points.glsl");
+    pv_parent->openShaderFile(m_initialPointShader);
 
     setFocus();
 }

--- a/src/view3d.h
+++ b/src/view3d.h
@@ -33,7 +33,8 @@ class View3D : public QGLWidget
 {
     Q_OBJECT
     public:
-        View3D(GeometryCollection* geometries, const QGLFormat& format, QWidget *parent = NULL);
+        View3D(GeometryCollection* geometries, const QGLFormat & format, QWidget *parent = NULL, 
+               const QString initialPointShader = QString());
         ~View3D();
 
         /// Return shader used for displaying points
@@ -131,6 +132,8 @@ class View3D : public QGLWidget
         bool m_drawGrid;
         /// If true, OpenGL initialization didn't work properly
         bool m_badOpenGL;
+
+        QString m_initialPointShader;
         /// Shader for point clouds
         std::unique_ptr<ShaderProgram> m_shaderProgram;
         /// Shaders for polygonal geometry


### PR DESCRIPTION
I just ran into the following problem: I wanted to adjust initial point radius, exposure etc so I copied the original las_points.glsl, made some changes, and specified my new glsl file on the command line using the -shader option. However, my changes to these parameters didn't have any effect, because the default point shader was loaded at start up time in view3d.cpp, and because of lines 346-347 in shader.cpp, the parameters were not updated when displaz-gui received the OPEN_SHADER command to open my new shader file. 

I don't quite understand the reason for lines 346-347 in shader.cpp and my initial quick fix was to simply comment them out. Then, looking a bit closer at the OPEN_SHADER command, I realized that it's only executed when starting a new instance of displaz-gui anyway. Maybe options that are only valid at gui start up should be passed to displaz-gui as command line parameters rather than commands? In any case, feel free to merge this pull request if it makes sense to you. 