### PR TITLE
More compiler warnings

### DIFF
--- a/src/las_io.cpp
+++ b/src/las_io.cpp
@@ -45,7 +45,9 @@ bool PointArray::loadLas(QString fileName, size_t maxPointCount,
 #elif __GNUC__
 #   pragma GCC diagnostic push
 #   pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#   ifndef __clang__
 #   pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#   endif
 #endif
 // Note... laslib generates a small horde of warnings
 #include <lasreader.hpp>

--- a/src/streampagecache_test.cpp
+++ b/src/streampagecache_test.cpp
@@ -8,6 +8,11 @@
 
 #include "streampagecache.h"
 
+// gcc 4.6 and 4.7 warns/suggests parentheses around == comparison
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wparentheses"
+#endif
+
 TEST_CASE("Test page cache for std::istream")
 {
     const size_t size = 12345;

--- a/src/util_test.cpp
+++ b/src/util_test.cpp
@@ -5,6 +5,11 @@
 
 #include "util.h"
 
+// gcc 4.6 and 4.7 warns/suggests parentheses around == comparison
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wparentheses"
+#endif
+
 int identity(int i) { return i; }
 
 TEST_CASE("Simple test for multi_partition")


### PR DESCRIPTION
gcc and clang compiler warnings for gcc 4.6, 4.7, 4.8, 4.9 and clang 3.6.0

![warnings2](https://cloud.githubusercontent.com/assets/545677/14226168/577fbe1c-f91d-11e5-8118-b0a9681ed4bd.png)

The remaining one seems harmless enough:

```
HCloudView.cpp:142, GNU Make + GNU C Compiler (gcc), Priority: Normal
function 'drawBounds' is not needed and will not be emitted [-Wunneeded-internal-declaration]
```