### PR TITLE
Opengl buffer bind cleanup

### DIFF
--- a/src/render/Geometry.cpp
+++ b/src/render/Geometry.cpp
@@ -125,7 +125,6 @@ void Geometry::initializeBboxGL(unsigned int bboxShader)
             4,5, 5,6, 6,7, 7,4
     };
 
-
     // create VBA VBO for rendering ...
     GLuint bboxVertexArray;
     glGenVertexArrays(1, &bboxVertexArray);
@@ -133,26 +132,19 @@ void Geometry::initializeBboxGL(unsigned int bboxShader)
 
     setVAO("boundingbox", bboxVertexArray);
 
-    GLuint geomVertexBuffer;
-    glGenBuffers(1, &geomVertexBuffer);
-    glBindBuffer(GL_ARRAY_BUFFER, geomVertexBuffer);
-
-    setVBO("bbox_vertex", geomVertexBuffer);
-
+    GlBuffer positionBuffer;
+    positionBuffer.bind(GL_ARRAY_BUFFER);
     glBufferData(GL_ARRAY_BUFFER, 3*8*sizeof(float), verts, GL_STATIC_DRAW);
 
     GLuint positionAttribute = glGetAttribLocation(bboxShader, "position");
-
     glVertexAttribPointer(positionAttribute, 3, GL_FLOAT, GL_FALSE, sizeof(float)*(3), (const GLvoid *)0);
     glEnableVertexAttribArray(positionAttribute);
 
-    GLuint geomElementBuffer;
-    glGenBuffers(1, &geomElementBuffer);
-
-    setVBO("bbox_index", geomElementBuffer);
-
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, geomElementBuffer);
+    GlBuffer elementBuffer;
+    elementBuffer.bind(GL_ELEMENT_ARRAY_BUFFER);
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, 2*4*3*sizeof(char), inds, GL_STATIC_DRAW);
+
+    glBindVertexArray(0);
 }
 
 const unsigned int Geometry::getVAO(const char * vertexArrayName) const

--- a/src/render/PointArray.cpp
+++ b/src/render/PointArray.cpp
@@ -551,12 +551,10 @@ void PointArray::initializeGL()
 
     GLuint vao;
     glGenVertexArrays(1, &vao);
-    glBindVertexArray(vao);
     setVAO("points", vao);
 
     GLuint vbo;
     glGenBuffers(1, &vbo);
-    glBindBuffer(GL_ARRAY_BUFFER, vbo);
     setVBO("point_buffer", vbo);
 }
 
@@ -567,7 +565,6 @@ void PointArray::draw(const TransformState& transState, double quality) const
 DrawCount PointArray::drawPoints(QGLShaderProgram& prog, const TransformState& transState,
                                  double quality, bool incrementalDraw) const
 {
-
     GLuint vao = getVAO("points");
     glBindVertexArray(vao);
 
@@ -730,6 +727,9 @@ DrawCount PointArray::drawPoints(QGLShaderProgram& prog, const TransformState& t
         if (attributes[i])
             prog.disableAttributeArray(attributes[i]->location);
     }
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindVertexArray(0);
 
     return drawCount;
 }

--- a/src/render/TriMesh.cpp
+++ b/src/render/TriMesh.cpp
@@ -413,6 +413,7 @@ void TriMesh::initializeVertexGL(const char * vertArrayName, const std::vector<u
     {
         if (m_texcoords.empty())
         {
+            glDisableVertexAttribArray(texcoordsLocation);
             glVertexAttrib2f(texcoordsLocation, 0, 0);
         }
         else

--- a/src/render/View3D.cpp
+++ b/src/render/View3D.cpp
@@ -620,17 +620,15 @@ void View3D::initCursor(float cursorRadius, float centerPointRadius)
     glGenVertexArrays(1, &m_cursorVertexArray);
     glBindVertexArray(m_cursorVertexArray);
 
-    GLuint cursorVertexBuffer;
-    glGenBuffers(1, &cursorVertexBuffer);
-    glBindBuffer(GL_ARRAY_BUFFER, cursorVertexBuffer);
+    GlBuffer positionBuffer;
+    positionBuffer.bind(GL_ARRAY_BUFFER);
     glBufferData(GL_ARRAY_BUFFER, (3) * 8 * sizeof(float), cursorPoints, GL_STATIC_DRAW);
 
     GLuint positionAttribute = glGetAttribLocation(m_cursorShader->shaderProgram().programId(), "position");
-
     glVertexAttribPointer(positionAttribute, 3, GL_FLOAT, GL_FALSE, sizeof(float)*(3), (const GLvoid *)0);
     glEnableVertexAttribArray(positionAttribute);
 
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindVertexArray(0);
 }
 
 /// Draw the 3D cursor
@@ -695,6 +693,8 @@ void View3D::drawCursor(const TransformState& transStateIn, const V3d& cursorPos
         cursorShader.setUniformValue("color", 0.0f, 0.0f, 0.0f, 1.0f);
         transState.setUniforms(cursorShader.programId());
         glDrawArrays( GL_LINES, 0, 8 );
+
+        glBindVertexArray(0);
     }
 }
 
@@ -743,6 +743,7 @@ void View3D::initAxes()
     glEnableVertexAttribArray(texCoordAttribute);
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindVertexArray(0);
 
 
     const GLint l = 16;     // Label is 16 pixels wide
@@ -771,6 +772,7 @@ void View3D::initAxes()
 
     glVertexAttribPointer(texCoordAttribute, 2, GL_FLOAT, GL_FALSE, sizeof(float)*(2 + 2), (const GLvoid *)(sizeof(float)*2));
     glEnableVertexAttribArray(texCoordAttribute);
+    glBindVertexArray(0);
 
 
     // Center of axis overlay
@@ -813,6 +815,7 @@ void View3D::initAxes()
     //glBindFragDataLocation(m_axesShader->shaderProgram().programId(), 0, "fragColor");
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindVertexArray(0);
 }
 
 void View3D::drawAxes() const
@@ -879,6 +882,8 @@ void View3D::drawAxes() const
         glLineWidth(1); // this won't work anymore for values larger than 1 (4.0f);
         glDrawArrays( GL_LINES, 0, 6 );
         // do NOT release shader, this is no longer supported in OpenGL 3.2
+
+        glBindVertexArray(0);
     }
 
     // Draw Labels
@@ -926,6 +931,8 @@ void View3D::drawAxes() const
         // draw
         glDrawArrays( GL_TRIANGLES, 0, 6 );
         // do NOT release shader, this is no longer supported in OpenGL 3.2
+
+        glBindVertexArray(0);
     }
 }
 
@@ -980,6 +987,7 @@ void View3D::initGrid(const float scale)
     glEnableVertexAttribArray(positionAttribute);
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindVertexArray(0);
 }
 
 void View3D::drawGrid() const
@@ -1006,6 +1014,7 @@ void View3D::drawGrid() const
         glLineWidth(1); // this won't work anymore for values larger than 1 (2.0f);
         glDrawArrays(GL_LINES, 0, (22 * 2));
         // do NOT release shader, this is no longer supported in OpenGL 3.2
+        glBindVertexArray(0);
     }
 }
 

--- a/src/render/glutil.cpp
+++ b/src/render/glutil.cpp
@@ -115,6 +115,7 @@ void drawBoundingBox(const TransformState& transState,
 
     glBindVertexArray(bboxVertexArray);
     glDrawElements(GL_LINES, 3*8, GL_UNSIGNED_BYTE, 0);
+    glBindVertexArray(0);
 
     glDisable(GL_BLEND);
     glDisable(GL_LINE_SMOOTH);


### PR DESCRIPTION
Finally get to the bottom of #86 - as expected a stale piece of OpenGL state, in this case it was the vertex array object which wasn't unbound.  Inside this VAO was referenced a vertex buffer object with a pointer to CPU memory which could become stale when a geometry object was deleted.  Eventually the driver would access this stale memory, causing a segfault in the driver.  Ugh!

@r-chris - note that VAOs should be carefully unbound or this kind of thing happens due to opengl global state leaking.  It's permissible to delete the VBOs used to pass data as long as the VAO is unbound first (forcing the VAO to keep the reference around internally).