### PR TITLE
Fixes for non-RGBA textures

### DIFF
--- a/src/render/TriMesh.cpp
+++ b/src/render/TriMesh.cpp
@@ -323,8 +323,11 @@ bool TriMesh::loadFile(QString fileName, size_t /*maxVertexCount*/)
     m_edges.swap(info.edges);
     if (!info.textureFileName.isEmpty())
     {
-        g_logger.info("Loading texture from %s", info.textureFileName);
-        m_texture.reset(new Texture(QImage(info.textureFileName)));
+        QImage image;
+        if (image.load(info.textureFileName))
+            m_texture.reset(new Texture(image));
+        else
+            g_logger.warning("Could not load texture %s for model %s", info.textureFileName, fileName);
     }
     //makeSmoothNormals(m_normals, m_verts, m_triangles);
     //makeEdges(m_edges, m_triangles);

--- a/src/render/glutil.h
+++ b/src/render/glutil.h
@@ -16,6 +16,7 @@
 #define QT_NO_OPENGL_ES_2
 
 #include <QImage>
+#include <QGLWidget>
 
 #include <vector>
 #include <cassert>
@@ -191,19 +192,11 @@ private:
 class Texture
 {
 public:
-    Texture(const QImage& i)
-        : m_image(i),
+    Texture(const QImage& image)
+        : m_image(QGLWidget::convertToGLFormat(image)),
         m_target(GL_TEXTURE_2D),
         m_texture(0)
-    {
-        // Convert to 32-bit pixel format to ease OpenGL interop.
-        if (m_image.format() != QImage::Format_ARGB32 &&
-            m_image.format() != QImage::Format_RGB32)
-        {
-            m_image.convertToFormat(m_image.hasAlphaChannel() ?
-                                    QImage::Format_ARGB32 : QImage::Format_RGB32);
-        }
-    }
+    { }
 
     ~Texture()
     {
@@ -219,9 +212,8 @@ public:
         {
             glGenTextures(1, &m_texture);
             glBindTexture(m_target, m_texture);
-            GLenum format = m_image.hasAlphaChannel() ? GL_BGRA : GL_BGR;
             glTexImage2D(m_target, 0, GL_RGBA, m_image.width(), m_image.height(),
-                         0, format, GL_UNSIGNED_BYTE, m_image.constBits());
+                         0, GL_RGBA, GL_UNSIGNED_BYTE, m_image.constBits());
             glTexParameterf(m_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
             glTexParameterf(m_target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
             glTexParameteri(m_target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);


### PR DESCRIPTION
* Use QGLWidget::convertToGLFormat() to produce a QImage with OpenGL
  GL_RGBA compatible bit layout rather than doing it manually.
* Warn when a texture is missing
* Remove info logging when loading textures

Fixes #114