### PR TITLE
RFC: Changed mouse controls

### DIFF
--- a/src/render/View3D.cpp
+++ b/src/render/View3D.cpp
@@ -534,6 +534,11 @@ void View3D::mousePressEvent(QMouseEvent* event)
     }
 }
 
+void View3D::mouseDoubleClickEvent(QMouseEvent* event)
+{
+    snapToPoint(guessClickPosition(event->pos()));
+}
+
 void View3D::snapToPoint(const Imath::V3d & pos)
 {
 
@@ -561,16 +566,16 @@ void View3D::mouseMoveEvent(QMouseEvent* event)
 {
     if (m_mouseButton == Qt::MidButton)
         return;
-    bool zooming = m_mouseButton == Qt::RightButton;
+    bool panning = (m_mouseButton == Qt::RightButton);
     if(event->modifiers() & Qt::ControlModifier)
     {
         m_cursorPos = m_camera.mouseMovePoint(m_cursorPos,
                                               event->pos() - m_prevMousePos,
-                                              zooming);
+                                              panning);
         restartRender();
     }
     else
-        m_camera.mouseDrag(m_prevMousePos, event->pos(), zooming);
+        m_camera.mouseDrag(m_prevMousePos, event->pos(), panning);
 
     m_prevMousePos = event->pos();
 }
@@ -579,7 +584,7 @@ void View3D::mouseMoveEvent(QMouseEvent* event)
 void View3D::wheelEvent(QWheelEvent* event)
 {
     // Translate mouse wheel events into vertical dragging for simplicity.
-    m_camera.mouseDrag(QPoint(0,0), QPoint(0, -event->delta()/2), true);
+    m_camera.mouseZoom(QPoint(0,0), QPoint(0, -event->delta()/2));
 }
 
 

--- a/src/render/View3D.h
+++ b/src/render/View3D.h
@@ -73,6 +73,7 @@ class View3D : public QGLWidget
 
         // Qt event callbacks
         void mousePressEvent(QMouseEvent* event);
+        void mouseDoubleClickEvent(QMouseEvent* event);
         void mouseMoveEvent(QMouseEvent* event);
         void wheelEvent(QWheelEvent* event);
         void keyPressEvent(QKeyEvent* event);


### PR DESCRIPTION
I'd like some feedback on some possible UI modifications I'm playing with in displaz. Some things I'm considering when designing this include the fact that its difficult to press the middle mouse button on modern mice, a UI which is consistent with possible future touch controls, and an analogue/continuous method for translating the centre of view.

Specific modifications are:

* Double click for select point and recenter
* Right click becomes pan. In standard mode it pans in the x-y plane. In
  trackball mode it pans in the camera/image plane. Might be nice for
  touchscreen interface with two finger pan, one finger rotate, and pinch-to-zoom?
* Seperate codepath for mouse wheel (same UI effect though)

For panning, the choices I've made specifically ignore the point cloud *and* the location on the screen the user initiates the drag from. We still need controls (maybe keyboard bindings) for z displacements.

Also, possibly standard WASD controls would obviate the need for pan-by-mouse mode and be more familiar to gamers. I think we'd want Q/Z or something for going up/down.