### PR TITLE
Fix logging explosion

### DIFF
--- a/src/PolygonBuilder.cpp
+++ b/src/PolygonBuilder.cpp
@@ -29,7 +29,7 @@ static void initTPPLPoly(TPPLPoly& poly,
          verts[3*inds[0]+1] == verts[3*inds[size-1]+1] &&
          verts[3*inds[0]+2] == verts[3*inds[size-1]+2]))
     {
-        g_logger.warning("Ignoring duplicate final vertex in explicitly closed polygon");
+        g_logger.warning_limited("Ignoring duplicate final vertex in explicitly closed polygon");
         size -= 1;
     }
     // Copy into polypartition data structure

--- a/src/gui/QtLogger.h
+++ b/src/gui/QtLogger.h
@@ -18,11 +18,6 @@ class QtLogger : public QObject, public Logger
     public:
         QtLogger(QObject* parent = 0) : QObject(parent) {}
 
-        virtual void log(LogLevel level, const std::string& msg)
-        {
-            emit logMessage(level, QString::fromUtf8(msg.c_str()));
-        }
-
     signals:
         /// Signal emitted every time a log message comes in
         void logMessage(int logLevel, QString msg);
@@ -31,6 +26,11 @@ class QtLogger : public QObject, public Logger
         void progressPercent(int percent);
 
     protected:
+        virtual void logImpl(LogLevel level, const std::string& msg)
+        {
+            emit logMessage(level, QString::fromUtf8(msg.c_str()));
+        }
+
         virtual void progressImpl(double progressFraction)
         {
             emit progressPercent(int(100*progressFraction));

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -5,6 +5,16 @@
 
 #include <cmath>
 
+//------------------------------------------------------------------------------
+void Logger::log(LogLevel level, const char* fmt, tfm::FormatListRef flist)
+{
+    if (level > m_logLevel)
+        return;
+    std::ostringstream ss;
+    tfm::vformat(ss, fmt, flist);
+    logImpl(level, ss.str());
+}
+
 
 //------------------------------------------------------------------------------
 StreamLogger::StreamLogger(std::ostream& outStream)
@@ -19,7 +29,7 @@ StreamLogger::~StreamLogger()
         m_out << "\n";
 }
 
-void StreamLogger::log(LogLevel level, const std::string& msg)
+void StreamLogger::logImpl(LogLevel level, const std::string& msg)
 {
     if (m_prevPrintWasProgress)
         tfm::format(m_out, "\n");

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -6,10 +6,17 @@
 #include <cmath>
 
 //------------------------------------------------------------------------------
-void Logger::log(LogLevel level, const char* fmt, tfm::FormatListRef flist)
+void Logger::log(LogLevel level, const char* fmt, tfm::FormatListRef flist, int maxMsgs)
 {
     if (level > m_logLevel)
         return;
+    if (maxMsgs > 0)
+    {
+        int& count = m_logCountLimit[LogCountKey(fmt, level)];
+        if (count >= maxMsgs)
+            return;
+        ++count;
+    }
     std::ostringstream ss;
     tfm::vformat(ss, fmt, flist);
     logImpl(level, ss.str());

--- a/src/logger.h
+++ b/src/logger.h
@@ -32,50 +32,45 @@ class Logger
         template<TINYFORMAT_ARGTYPES(n)>                                   \
         void progress(const char* fmt, TINYFORMAT_VARARGS(n))              \
         {                                                                  \
-            if (m_logProgress)                                             \
-                log(Progress, tfm::format(fmt, TINYFORMAT_PASSARGS(n)));   \
+            log(Progress, fmt, tfm::makeFormatList(TINYFORMAT_PASSARGS(n)));\
         }                                                                  \
                                                                            \
         template<TINYFORMAT_ARGTYPES(n)>                                   \
         void debug(const char* fmt, TINYFORMAT_VARARGS(n))                 \
         {                                                                  \
-            if (m_logLevel >= Debug)                                       \
-                log(Debug, tfm::format(fmt, TINYFORMAT_PASSARGS(n)));      \
+            log(Debug, fmt, tfm::makeFormatList(TINYFORMAT_PASSARGS(n)));  \
         }                                                                  \
                                                                            \
         template<TINYFORMAT_ARGTYPES(n)>                                   \
         void info(const char* fmt, TINYFORMAT_VARARGS(n))                  \
         {                                                                  \
-            if (m_logLevel >= Info)                                        \
-                log(Info, tfm::format(fmt, TINYFORMAT_PASSARGS(n)));       \
+            log(Info, fmt, tfm::makeFormatList(TINYFORMAT_PASSARGS(n)));   \
         }                                                                  \
                                                                            \
         template<TINYFORMAT_ARGTYPES(n)>                                   \
         void warning(const char* fmt, TINYFORMAT_VARARGS(n))               \
         {                                                                  \
-            if (m_logLevel >= Warning)                                     \
-                log(Warning, tfm::format(fmt, TINYFORMAT_PASSARGS(n)));    \
+            log(Warning, fmt, tfm::makeFormatList(TINYFORMAT_PASSARGS(n)));\
         }                                                                  \
                                                                            \
         template<TINYFORMAT_ARGTYPES(n)>                                   \
         void error(const char* fmt, TINYFORMAT_VARARGS(n))                 \
         {                                                                  \
-            if (m_logLevel >= Error)                                       \
-                log(Error, tfm::format(fmt, TINYFORMAT_PASSARGS(n)));      \
+            log(Error, fmt, tfm::makeFormatList(TINYFORMAT_PASSARGS(n)));  \
         }
 
         TINYFORMAT_FOREACH_ARGNUM(DISPLAZ_MAKE_LOG_FUNCS)
 #       undef DISPLAZ_MAKE_LOG_FUNCS
 
         // 0-arg versions
-        void progress (const char* fmt) { log(Progress, tfm::format(fmt)); }
-        void debug    (const char* fmt) { log(Debug, tfm::format(fmt)); }
-        void info     (const char* fmt) { log(Info, tfm::format(fmt)); }
-        void warning  (const char* fmt) { log(Warning, tfm::format(fmt)); }
-        void error    (const char* fmt) { log(Error, tfm::format(fmt)); }
+        void progress (const char* fmt) { log(Progress, fmt, tfm::makeFormatList()); }
+        void debug    (const char* fmt) { log(Debug,    fmt, tfm::makeFormatList()); }
+        void info     (const char* fmt) { log(Info,     fmt, tfm::makeFormatList()); }
+        void warning  (const char* fmt) { log(Warning,  fmt, tfm::makeFormatList()); }
+        void error    (const char* fmt) { log(Error,    fmt, tfm::makeFormatList()); }
 
-        /// Log message at the given log level
-        virtual void log(LogLevel level, const std::string& msg) = 0;
+        /// Log format list at the given log level
+        virtual void log(LogLevel level, const char* fmt, tfm::FormatListRef flist);
 
         /// Report progress of some processing step
         void progress(double progressFraction)
@@ -85,6 +80,8 @@ class Logger
         }
 
     protected:
+        virtual void logImpl(LogLevel level, const std::string& msg) = 0;
+
         virtual void progressImpl(double progressFraction) = 0;
 
     private:
@@ -100,9 +97,9 @@ class StreamLogger : public Logger
         StreamLogger(std::ostream& outStream);
         ~StreamLogger();
 
-        virtual void log(LogLevel level, const std::string& msg);
-
     protected:
+        virtual void logImpl(LogLevel level, const std::string& msg);
+
         virtual void progressImpl(double progressFraction);
 
     private:


### PR DESCRIPTION
Some fixes to avoid qt completely bogging down with a large number of log messages reading some old polygon data.