### PR TITLE
Add displaz-gui -server option to ease debugging

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -203,6 +203,18 @@ SigIntTransferHandler::~SigIntTransferHandler()
 
 
 //------------------------------------------------------------------------------
+void getDisplazIpcNames(std::string& socketName, std::string& lockFileName,
+                        const std::string& serverName)
+{
+    std::string id = "displaz-ipc-" + currentUserUid();
+    if (!serverName.empty())
+        id += "-" + serverName;
+    socketName = id;
+    lockFileName = id + ".lock";
+}
+
+
+//------------------------------------------------------------------------------
 bool iequals(const std::string& a, const std::string& b)
 {
     if (a.size() != b.size())

--- a/src/util.h
+++ b/src/util.h
@@ -236,6 +236,14 @@ class SigIntTransferHandler
 };
 
 
+/// Get socket and lock file names for displaz IPC
+///
+/// This is a combination of the program name and user name to avoid any name
+/// clashes, along with a user-defined serverName.
+void getDisplazIpcNames(std::string& socketName, std::string& lockFileName,
+                        const std::string& serverName);
+
+
 //------------------------------------------------------------------------------
 // String utils
 


### PR DESCRIPTION
Normally the GUI will inherit an instance lock from the command line
tool, but this makes debugging quite hard; add a -server option to allow
the GUI to be started manually.

@awbsmith I hope this helps with debugging your problem.