### PR TITLE
Fix horrible bug: glDeleteBuffers used instead of glDeleteVertexArrays

### DIFF
--- a/src/render/Geometry.cpp
+++ b/src/render/Geometry.cpp
@@ -87,7 +87,7 @@ void Geometry::destroyBuffers()
     for (auto& it: m_VAO)
     {
         GLuint vao = it.second;
-        glDeleteBuffers(1, &vao);
+        glDeleteVertexArrays(1, &vao);
     }
 
     m_VAO.clear();


### PR DESCRIPTION
OMSDLFKJG this was hard to find, thank goodness for apitrace.

The bug It leads to some VBOs (particularly that used by PointArray)
being randomly deleted before we're done with them, intermittently
leading to segfaults inside the driver.  Driver- and OS-dependent
madness!

Another effect of this bug was that vertex array handles continually
leaked.  This is probably the cause of some lower powered cards
eventually locking up under resource starvation.