### PR TITLE
WIP: Mutate a subset of vertices from command line

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,6 +83,7 @@ displaz_qt_wrap_cpp(gui_moc_srcs
     render/View3D.h
     render/PointArray.h
     render/Shader.h
+    render/GeometryMutator.h
 )
 
 set(gui_srcs
@@ -110,6 +111,7 @@ set(gui_srcs
     render/PointArray.cpp
     render/View3D.cpp
     render/Shader.cpp
+    render/GeometryMutator.cpp
 
     ../thirdparty/rply/rply.c
     ../thirdparty/polypartition/polypartition.cpp
@@ -280,4 +282,3 @@ if (DISPLAZ_USE_TESTS)
     endif ()
     add_test(NAME InterProcessLock_test COMMAND InterProcessLock_test master)
 endif()
-

--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -110,12 +110,15 @@ class FileLoader : public QObject
         void loadFileImpl(const FileLoadInfo& loadInfo, bool reloaded)
         {
             // Different codepath for mutating existing data.
+            // TODO Geometry and GeometryMutator have different exception handling
+            //      that could be made more consistent.
             if (loadInfo.mutateExisting)
             {
                 std::shared_ptr<GeometryMutator> mutator(new GeometryMutator());
                 if (!mutator->loadFile(loadInfo.filePath))
                 {
                     g_logger.error("Could not load %s", loadInfo.filePath);
+                    return;
                 }
                 mutator->moveToThread(0);
                 mutator->setLabel(loadInfo.dataSetLabel);

--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -113,7 +113,10 @@ class FileLoader : public QObject
             if (loadInfo.mutateExisting)
             {
                 std::shared_ptr<GeometryMutator> mutator(new GeometryMutator());
-                mutator->loadFile(loadInfo.filePath);
+                if (!mutator->loadFile(loadInfo.filePath))
+                {
+                    g_logger.error("Could not load %s", loadInfo.filePath);
+                }
                 mutator->moveToThread(0);
                 mutator->setLabel(loadInfo.dataSetLabel);
                 emit geometryMutatorLoaded(mutator);

--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -115,7 +115,9 @@ class FileLoader : public QObject
                 std::shared_ptr<GeometryMutator> mutator(new GeometryMutator());
                 mutator->loadFile(loadInfo.filePath);
                 mutator->moveToThread(0);
+                mutator->setLabel(loadInfo.dataSetLabel);
                 emit geometryMutatorLoaded(mutator);
+
                 if (loadInfo.deleteAfterLoad)
                 {
                     // Only delete after successful load:  Load errors

--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -22,15 +22,17 @@ struct FileLoadInfo
     QString dataSetLabel; /// Human readable label for the dataset
     bool replaceLabel;    /// Replace any existing dataset in the UI with the same label
     bool deleteAfterLoad; /// Delete file after load - for use with temporary files.
+    bool mutateExisting;  /// Replace vertex data in-place and discard the result
 
-    FileLoadInfo() : replaceLabel(true), deleteAfterLoad(false) {}
+    FileLoadInfo() : replaceLabel(true), deleteAfterLoad(false), mutateExisting(false) {}
     FileLoadInfo(const QString& filePath_, const QString& dataSetLabel_ = "",
                  bool replaceLabel_ = true)
         : filePath(filePath_),
         dataSetLabel(dataSetLabel_),
         replaceLabel(replaceLabel_),
         // Following must be set explicitly - getting it wrong will delete user data!
-        deleteAfterLoad(false)
+        deleteAfterLoad(false),
+        mutateExisting(false)
     {
         if (dataSetLabel_.isEmpty())
         {
@@ -94,6 +96,8 @@ class FileLoader : public QObject
         void geometryLoaded(std::shared_ptr<Geometry> geom,
                             bool replaceLabel, bool reloaded);
 
+        void geometryMutatorLoaded(std::shared_ptr<GeometryMutator> mutator);
+
     private slots:
         void asyncLoadFile(const FileLoadInfo& loadInfo, bool reloaded)
         {
@@ -105,6 +109,24 @@ class FileLoader : public QObject
 
         void loadFileImpl(const FileLoadInfo& loadInfo, bool reloaded)
         {
+            // Different codepath for mutating existing data.
+            if (loadInfo.mutateExisting)
+            {
+                std::shared_ptr<GeometryMutator> mutator(new GeometryMutator());
+                mutator->loadFile(loadInfo.filePath);
+                mutator->moveToThread(0);
+                emit geometryMutatorLoaded(mutator);
+                if (loadInfo.deleteAfterLoad)
+                {
+                    // Only delete after successful load:  Load errors
+                    // are somewhat likely to be user error trying to load
+                    // something they didn't mean to.
+                    QFile::remove(loadInfo.filePath);
+                }
+                return;
+            }
+
+            // Standard loading code
             std::shared_ptr<Geometry> geom = Geometry::create(loadInfo.filePath);
             geom->setLabel(loadInfo.dataSetLabel);
             connect(geom.get(), SIGNAL(loadProgress(int)),

--- a/src/geometrycollection.cpp
+++ b/src/geometrycollection.cpp
@@ -137,7 +137,7 @@ void GeometryCollection::mutateGeometry(std::shared_ptr<GeometryMutator> mutator
 {
     mutator->moveToThread(QThread::currentThread());
 
-    g_logger.info("Attempting to mutate data with label \"%s\"\n", mutator->label());
+    g_logger.info("Attempting to mutate data with label \"%s\"", mutator->label());
 
     for (size_t i = 0; i < m_geometries.size(); ++i)
     {

--- a/src/geometrycollection.cpp
+++ b/src/geometrycollection.cpp
@@ -131,3 +131,21 @@ void GeometryCollection::addGeometry(std::shared_ptr<Geometry> geom,
     m_geometries.push_back(geom);
     emit endInsertRows();
 }
+
+void GeometryCollection::mutateGeometry(std::shared_ptr<GeometryMutator> mutator)
+{
+    mutator->moveToThread(QThread::currentThread());
+
+    for (size_t i = 0; i < m_geometries.size(); ++i)
+    {
+        if ( m_geometries[i]->label() == mutator->label());
+        {
+            m_geometries[i]->mutate(mutator);
+
+            QModelIndex idx = createIndex((int)i, 0);
+            emit dataChanged(idx, idx);
+
+            return;
+        }
+    }
+}

--- a/src/geometrycollection.cpp
+++ b/src/geometrycollection.cpp
@@ -8,6 +8,7 @@
 
 #include <QRegExp>
 #include <QThread>
+#include <QDebug>
 
 GeometryCollection::GeometryCollection(QObject* parent)
     : QAbstractListModel(parent)
@@ -136,9 +137,11 @@ void GeometryCollection::mutateGeometry(std::shared_ptr<GeometryMutator> mutator
 {
     mutator->moveToThread(QThread::currentThread());
 
+    g_logger.info("Attempting to mutate data with label \"%s\"\n", mutator->label());
+
     for (size_t i = 0; i < m_geometries.size(); ++i)
     {
-        if ( m_geometries[i]->label() == mutator->label());
+        if ( m_geometries[i]->label() == mutator->label() )
         {
             m_geometries[i]->mutate(mutator);
 
@@ -148,4 +151,5 @@ void GeometryCollection::mutateGeometry(std::shared_ptr<GeometryMutator> mutator
             return;
         }
     }
+    g_logger.error("Didn't match mutation label \"%s\"\n", mutator->label());
 }

--- a/src/geometrycollection.h
+++ b/src/geometrycollection.h
@@ -11,6 +11,7 @@
 
 #include "Geometry.h"
 #include "fileloader.h"
+#include "GeometryMutator.h"
 
 class QRegExp;
 
@@ -55,6 +56,8 @@ class GeometryCollection : public QAbstractListModel
         /// If `replaceLabel` is true, search existing geometry for a matching
         /// `geom->label()` and replace the existing geometry if found.
         void addGeometry(std::shared_ptr<Geometry> geom, bool replaceLabel = false, bool reloaded = false);
+        void mutateGeometry(std::shared_ptr<GeometryMutator> mutator);
+
 
     private:
         void loadPointFilesImpl(const QStringList& fileNames, bool removeAfterLoad);

--- a/src/geomfield.h
+++ b/src/geomfield.h
@@ -43,6 +43,14 @@ struct GeomField
         return reinterpret_cast<T*>(data.get());
     }
 
+    /// Get pointer to the underlying data as array of the base spec
+    template<typename T>
+    const T* as() const
+    {
+        assert(sizeof(T) == spec.elsize);
+        return reinterpret_cast<const T*>(data.get());
+    }
+
     /// Print human readable form of `data[index]` to output stream
     void format(std::ostream& out, size_t index) const;
 

--- a/src/gui/PointViewerMainWindow.cpp
+++ b/src/gui/PointViewerMainWindow.cpp
@@ -78,6 +78,8 @@ PointViewerMainWindow::PointViewerMainWindow(const QGLFormat& format)
     //connect(m_fileLoader, SIGNAL(finished()), this, SIGNAL(fileLoadFinished()));
     connect(m_fileLoader, SIGNAL(geometryLoaded(std::shared_ptr<Geometry>, bool, bool)),
             m_geometries, SLOT(addGeometry(std::shared_ptr<Geometry>, bool, bool)));
+    connect(m_fileLoader, SIGNAL(geometryMutatorLoaded(std::shared_ptr<GeometryMutator>)),
+            m_geometries, SLOT(mutateGeometry(std::shared_ptr<GeometryMutator>)));
     loaderThread->start();
 
     //--------------------------------------------------
@@ -367,6 +369,7 @@ void PointViewerMainWindow::handleMessage(QByteArray message)
         QList<QByteArray> flags = commandTokens[1].split('\0');
         bool replaceLabel = flags.contains("REPLACE_LABEL");
         bool deleteAfterLoad = flags.contains("DELETE_AFTER_LOAD");
+        bool mutateExisting = flags.contains("MUTATE_EXISTING");
         for (int i = 2; i < commandTokens.size(); ++i)
         {
             QList<QByteArray> pathAndLabel = commandTokens[i].split('\0');
@@ -378,6 +381,7 @@ void PointViewerMainWindow::handleMessage(QByteArray message)
             }
             FileLoadInfo loadInfo(pathAndLabel[0], pathAndLabel[1], replaceLabel);
             loadInfo.deleteAfterLoad = deleteAfterLoad;
+            loadInfo.mutateExisting = mutateExisting;
             m_fileLoader->loadFile(loadInfo);
         }
     }

--- a/src/gui/guimain.cpp
+++ b/src/gui/guimain.cpp
@@ -14,6 +14,7 @@
 #include "util.h"
 
 class Geometry;
+class GeometryMutator;
 
 
 /// Set up search paths to our application directory for Qt's file search
@@ -72,6 +73,7 @@ int main(int argc, char* argv[])
     Q_INIT_RESOURCE(resource);
 
     qRegisterMetaType<std::shared_ptr<Geometry>>("std::shared_ptr<Geometry>");
+    qRegisterMetaType<std::shared_ptr<GeometryMutator>>("std::shared_ptr<GeometryMutator>");
 
     // Multisampled antialiasing - this makes rendered point clouds look much
     // nicer, but also makes the render much slower, especially on lower
@@ -106,4 +108,3 @@ int main(int argc, char* argv[])
     window.show();
     return app.exec();
 }
-

--- a/src/las_io.cpp
+++ b/src/las_io.cpp
@@ -13,8 +13,7 @@
 
 bool PointArray::loadLas(QString fileName, size_t maxPointCount,
                          std::vector<GeomField>& fields, V3d& offset,
-                         size_t& npoints, uint64_t& totalPoints,
-                         Imath::Box3d& bbox, V3d& centroid)
+                         size_t& npoints, uint64_t& totalPoints)
 {
     g_logger.error("Cannot load %s: Displaz built without las support!", fileName);
     return false;
@@ -67,10 +66,8 @@ class MonkeyChops { MonkeyChops() { (void)LAS_TOOLS_FORMAT_NAMES; } };
 
 bool PointArray::loadLas(QString fileName, size_t maxPointCount,
                          std::vector<GeomField>& fields, V3d& offset,
-                         size_t& npoints, uint64_t& totalPoints,
-                         Imath::Box3d& bbox, V3d& centroid)
+                         size_t& npoints, uint64_t& totalPoints)
 {
-    V3d Psum(0);
 #ifdef DISPLAZ_USE_PDAL
     // Open file
     if (!pdal::FileUtils::fileExists(fileName.toLatin1().constData()))
@@ -153,8 +150,6 @@ bool PointArray::loadLas(QString fileName, size_t maxPointCount,
 //             V3d P = V3d(xDim.applyScaling(buf.getField<int32_t>(xDim, i)),
 //                         yDim.applyScaling(buf.getField<int32_t>(yDim, i)),
 //                         zDim.applyScaling(buf.getField<int32_t>(zDim, i)));
-            bbox.extendBy(P);
-            Psum += P;
             if(readCount < nextStore)
                 continue;
             ++storeCount;
@@ -257,8 +252,6 @@ bool PointArray::loadLas(QString fileName, size_t maxPointCount,
         if(readCount % 10000 == 0)
             emit loadProgress(100*readCount/totalPoints);
         V3d P = V3d(point.get_x(), point.get_y(), point.get_z());
-        bbox.extendBy(P);
-        Psum += P;
         if(readCount < nextStore)
             continue;
         ++storeCount;
@@ -308,8 +301,6 @@ bool PointArray::loadLas(QString fileName, size_t maxPointCount,
             fields[i].size = npoints;
         totalPoints = readCount;
     }
-    if (totalPoints > 0)
-        centroid = (1.0/totalPoints)*Psum;
     return true;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,6 +66,7 @@ int main(int argc, char *argv[])
 
     bool clearFiles = false;
     bool addFiles = false;
+    bool mutateData = false;
     bool deleteAfterLoad = false;
     bool quitRemote = false;
     bool queryCursor = false;
@@ -108,6 +109,7 @@ int main(int argc, char *argv[])
         "-unload %s",    &unloadFiles,   "Remote: unload loaded files matching the given (unix shell style) pattern",
         "-quit",         &quitRemote,    "Remote: close the existing displaz window",
         "-add",          &addFiles,      "Remote: add files to currently open set, instead of replacing those with duplicate labels",
+        "-modify",       &mutateData,    "Remote: mutate data already loaded with the matching label (requires displaz .ply with an \"index\" field to indicate mutated points)",
         "-rmtemp",       &deleteAfterLoad, "*Delete* files after loading - use with caution to clean up single-use temporary files after loading",
         "-querycursor",  &queryCursor,   "Query 3D cursor location from displaz instance",
         "-script",       &script,        "Script mode: enable several settings which are useful when calling displaz from a script:"
@@ -211,6 +213,11 @@ int main(int argc, char *argv[])
         QByteArray command;
         QDir currentDir = QDir::current();
         command = "OPEN_FILES\n";
+        if (mutateData)
+        {
+            command += QByteArray("MUTATE_EXISTING");
+            command += '\0';
+        }
         if (!addFiles)
         {
             command += QByteArray("REPLACE_LABEL");

--- a/src/ply_io.cpp
+++ b/src/ply_io.cpp
@@ -302,13 +302,10 @@ bool loadPlyVertexProperties(QString fileName, p_ply ply, p_ply_element vertexEl
 // Utilities for loading ply in "displaz-native" format
 
 /// Find all elements with name "vertex_*"
-///
-/// The position element will always be in vertexElements[0] if present.
 bool findVertexElements(std::vector<p_ply_element>& vertexElements,
                         p_ply ply, size_t& npoints)
 {
     int64_t np = -1;
-    int positionIndex = -1;
     for (p_ply_element elem = ply_get_next_element(ply, NULL);
          elem != NULL; elem = ply_get_next_element(ply, elem))
     {
@@ -326,8 +323,6 @@ bool findVertexElements(std::vector<p_ply_element>& vertexElements,
                 return false;
             }
             vertexElements.push_back(elem);
-            if (strcmp(name, "vertex_position") == 0)
-                positionIndex = (int)vertexElements.size()-1;
         }
         else
         {
@@ -335,8 +330,6 @@ bool findVertexElements(std::vector<p_ply_element>& vertexElements,
         }
     }
 
-    if (positionIndex != -1 && positionIndex != 0)
-        std::swap(vertexElements[0], vertexElements[positionIndex]);
     npoints = np;
     return true;
 }

--- a/src/ply_io.cpp
+++ b/src/ply_io.cpp
@@ -334,11 +334,7 @@ bool findVertexElements(std::vector<p_ply_element>& vertexElements,
             g_logger.warning("Ignoring unrecogized ply element: %s", name);
         }
     }
-    /*if (positionIndex == -1)
-    {
-        g_logger.error("%s", "No vertex position found in ply file");
-        return false;
-    }*/
+
     if (positionIndex != -1 && positionIndex != 0)
         std::swap(vertexElements[0], vertexElements[positionIndex]);
     npoints = np;

--- a/src/ply_io.cpp
+++ b/src/ply_io.cpp
@@ -334,12 +334,12 @@ bool findVertexElements(std::vector<p_ply_element>& vertexElements,
             g_logger.warning("Ignoring unrecogized ply element: %s", name);
         }
     }
-    if (positionIndex == -1)
+    /*if (positionIndex == -1)
     {
         g_logger.error("%s", "No vertex position found in ply file");
         return false;
-    }
-    if (positionIndex != 0)
+    }*/
+    if (positionIndex != -1 && positionIndex != 0)
         std::swap(vertexElements[0], vertexElements[positionIndex]);
     npoints = np;
     return true;

--- a/src/ply_io.h
+++ b/src/ply_io.h
@@ -77,7 +77,7 @@ bool loadPlyVertexProperties(QString fileName, p_ply ply, p_ply_element vertexEl
 /// Parameters:
 ///   fileName - ply file name
 ///   ply - open ply file
-///   fields - returned point fields.  fields[0] will contain position
+///   fields - returned point fields.
 ///   offset - offset to be applied to position field
 ///   npoints - total number of points
 bool loadDisplazNativePly(QString fileName, p_ply ply,

--- a/src/render/Geometry.h
+++ b/src/render/Geometry.h
@@ -65,7 +65,10 @@ class Geometry : public QObject
         //--------------------------------------------------
         /// Mutate a geometry
         ///
-        /// Modify some geometry data with the data in a GeometryMutator
+        /// Apply a per-vertex modification of geometry data with the data in a 
+        /// GeometryMutator, which keeps an index to a subset of vertices and
+        /// new data for a subset of fields. The number of vertices remains
+        /// constant.
         virtual void mutate(std::shared_ptr<GeometryMutator> mutator) { }
 
         //--------------------------------------------------

--- a/src/render/Geometry.h
+++ b/src/render/Geometry.h
@@ -13,6 +13,8 @@
 #include <QString>
 #include <QMetaType>
 
+#include "GeometryMutator.h"
+
 class ShaderProgram;
 class QGLShaderProgram;
 struct TransformState;
@@ -59,6 +61,12 @@ class Geometry : public QObject
         /// Attempt to load no more than a maximum of maxVertexCount vertices,
         /// simplifying the geometry if possible.
         virtual bool loadFile(QString fileName, size_t maxVertexCount) = 0;
+
+        //--------------------------------------------------
+        /// Mutate a geometry
+        ///
+        /// Modify some geometry data with the data in a GeometryMutator
+        virtual void mutate(std::shared_ptr<GeometryMutator> mutator) { }
 
         //--------------------------------------------------
         /// Draw geometry using current OpenGL context

--- a/src/render/GeometryMutator.cpp
+++ b/src/render/GeometryMutator.cpp
@@ -58,7 +58,7 @@ bool GeometryMutator::loadFile(const QString& fileName)
         g_logger.error("No index field found in file %s", fileName);
         return false;
     }
-    m_index = (int*)m_fields[m_indexFieldIdx].as<int>();
+    m_index = (uint*)m_fields[m_indexFieldIdx].as<uint>();
 
     g_logger.info("Loaded %d point mutations from file %s",
                   m_npoints, fileName);

--- a/src/render/GeometryMutator.cpp
+++ b/src/render/GeometryMutator.cpp
@@ -1,0 +1,67 @@
+// Copyright 2015, Christopher J. Foster and the other displaz contributors.
+// Use of this code is governed by the BSD-style license found in LICENSE.txt
+
+#include "GeometryMutator.h"
+#include "ply_io.h"
+
+
+GeometryMutator::GeometryMutator()
+    : m_npoints(0),
+    m_indexFieldIdx(-1),
+    m_index(0)
+{ }
+
+
+GeometryMutator::~GeometryMutator()
+{ }
+
+
+
+bool GeometryMutator::loadFile(const QString& fileName)
+{
+    // Check it is ply
+    if (!fileName.endsWith(".ply"))
+    {
+        //g_logger.error("Expected ply for file %s", fileName);
+        return false;
+    }
+
+    std::unique_ptr<t_ply_, int(*)(p_ply)> ply(
+            ply_open(fileName.toUtf8().constData(), logRplyError, 0, NULL), ply_close);
+    if (!ply || !ply_read_header(ply.get()))
+        return false;
+    // Parse out header data
+    p_ply_element vertexElement = findVertexElement(ply.get(), m_npoints);
+    if (vertexElement)
+    {
+        //g_logger.error("Expected displaz formated ply for file %s", fileName);
+        return false;
+    }
+    else
+    {
+        if (!loadDisplazNativePly(fileName, ply.get(), m_fields, m_offset, m_npoints))
+            return false;
+    }
+
+    // Search for index field
+    m_indexFieldIdx = -1;
+    for (size_t i = 0; i < m_fields.size(); ++i)
+    {
+        if (m_fields[i].name == "index" && m_fields[i].spec.count == 1)
+        {
+            m_indexFieldIdx = (int)i;
+            break;
+        }
+    }
+    if (m_indexFieldIdx == -1)
+    {
+        //g_logger.error("No index field found in file %s", fileName);
+        return false;
+    }
+    m_index = (size_t*)m_fields[m_indexFieldIdx].as<size_t>();
+
+    //g_logger.info("Loaded %d point mutations from file %s in %.2f seconds",
+    //              m_npoints, fileName, loadTimer.elapsed()/1000.0);
+
+    return true;
+}

--- a/src/render/GeometryMutator.cpp
+++ b/src/render/GeometryMutator.cpp
@@ -36,7 +36,7 @@ bool GeometryMutator::loadFile(const QString& fileName)
         p_ply_element vertexElement = findVertexElement(ply.get(), m_npoints);
         if (vertexElement)
         {
-            g_logger.error("Expected displaz formated ply for file %s", fileName);
+            g_logger.error("Expected displaz formatted ply for file %s", fileName);
             return false;
         }
         else
@@ -55,18 +55,23 @@ bool GeometryMutator::loadFile(const QString& fileName)
     m_indexFieldIdx = -1;
     for (size_t i = 0; i < m_fields.size(); ++i)
     {
-        if (m_fields[i].name == "index" && m_fields[i].spec.count == 1)
+        if (m_fields[i].name == "index")
         {
+            if (!(m_fields[i].spec == TypeSpec::uint32()))
+            {
+                g_logger.error("The \"index\" field found in file %s is not of type uint32", fileName);
+                return false;
+            }
             m_indexFieldIdx = (int)i;
             break;
         }
     }
     if (m_indexFieldIdx == -1)
     {
-        g_logger.error("No index field found in file %s", fileName);
+        g_logger.error("No \"index\" field found in file %s", fileName);
         return false;
     }
-    m_index = (uint*)m_fields[m_indexFieldIdx].as<uint>();
+    m_index = m_fields[m_indexFieldIdx].as<uint32_t>();
 
     g_logger.info("Loaded %d point mutations from file %s",
                   m_npoints, fileName);

--- a/src/render/GeometryMutator.cpp
+++ b/src/render/GeometryMutator.cpp
@@ -3,7 +3,7 @@
 
 #include "GeometryMutator.h"
 #include "ply_io.h"
-
+#include "QtLogger.h"
 
 GeometryMutator::GeometryMutator()
     : m_npoints(0),
@@ -34,7 +34,7 @@ bool GeometryMutator::loadFile(const QString& fileName)
     p_ply_element vertexElement = findVertexElement(ply.get(), m_npoints);
     if (vertexElement)
     {
-        //g_logger.error("Expected displaz formated ply for file %s", fileName);
+        g_logger.error("Expected displaz formated ply for file %s", fileName);
         return false;
     }
     else
@@ -55,13 +55,13 @@ bool GeometryMutator::loadFile(const QString& fileName)
     }
     if (m_indexFieldIdx == -1)
     {
-        //g_logger.error("No index field found in file %s", fileName);
+        g_logger.error("No index field found in file %s", fileName);
         return false;
     }
-    m_index = (size_t*)m_fields[m_indexFieldIdx].as<size_t>();
+    m_index = (int*)m_fields[m_indexFieldIdx].as<int>();
 
-    //g_logger.info("Loaded %d point mutations from file %s in %.2f seconds",
-    //              m_npoints, fileName, loadTimer.elapsed()/1000.0);
+    g_logger.info("Loaded %d point mutations from file %s",
+                  m_npoints, fileName);
 
     return true;
 }

--- a/src/render/GeometryMutator.cpp
+++ b/src/render/GeometryMutator.cpp
@@ -22,25 +22,33 @@ bool GeometryMutator::loadFile(const QString& fileName)
     // Check it is ply
     if (!fileName.endsWith(".ply"))
     {
-        //g_logger.error("Expected ply for file %s", fileName);
+        g_logger.error("Expected ply for file %s", fileName);
         return false;
     }
 
-    std::unique_ptr<t_ply_, int(*)(p_ply)> ply(
-            ply_open(fileName.toUtf8().constData(), logRplyError, 0, NULL), ply_close);
-    if (!ply || !ply_read_header(ply.get()))
-        return false;
-    // Parse out header data
-    p_ply_element vertexElement = findVertexElement(ply.get(), m_npoints);
-    if (vertexElement)
+    try
     {
-        g_logger.error("Expected displaz formated ply for file %s", fileName);
-        return false;
-    }
-    else
-    {
-        if (!loadDisplazNativePly(fileName, ply.get(), m_fields, m_offset, m_npoints))
+        std::unique_ptr<t_ply_, int(*)(p_ply)> ply(
+                ply_open(fileName.toUtf8().constData(), logRplyError, 0, NULL), ply_close);
+        if (!ply || !ply_read_header(ply.get()))
             return false;
+        // Parse out header data
+        p_ply_element vertexElement = findVertexElement(ply.get(), m_npoints);
+        if (vertexElement)
+        {
+            g_logger.error("Expected displaz formated ply for file %s", fileName);
+            return false;
+        }
+        else
+        {
+            if (!loadDisplazNativePly(fileName, ply.get(), m_fields, m_offset, m_npoints))
+                return false;
+        }
+    }
+    catch(...)
+    {
+        g_logger.error("Unkown load error for file %s", fileName);
+        return false;
     }
 
     // Search for index field

--- a/src/render/GeometryMutator.h
+++ b/src/render/GeometryMutator.h
@@ -1,0 +1,65 @@
+// Copyright 2015, Christopher J. Foster and the other displaz contributors.
+// Use of this code is governed by the BSD-style license found in LICENSE.txt
+
+#ifndef DISPLAZ_GEOMETRYMUTATOR_H_INCLUDED
+#define DISPLAZ_GEOMETRYMUTATOR_H_INCLUDED
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <QObject>
+#include <QString>
+#include <QMetaType>
+#include "util.h"
+#include "typespec.h"
+#include "geomfield.h"
+
+
+//------------------------------------------------------------------------------
+/// Container for loaded data which will be used to modify (mutate) an
+/// existing PointArray.
+class GeometryMutator : public QObject
+{
+    Q_OBJECT
+
+    public:
+        GeometryMutator();
+        ~GeometryMutator();
+
+        bool loadFile(const QString& fileName);
+
+        /// Get the arbitrary user-defined label for the geometry.
+        const QString& label() const { return m_label; }
+
+        /// Set the arbitrary user-defined label for the geometry.
+        void setLabel(const QString& label) { m_label = label; }
+
+        /// Get number of points to mutate
+        size_t pointCount() const { return m_npoints; }
+
+        /// Get index of points to mutate
+        size_t* index() const { return m_index; }
+
+        /// Get fields to mutate
+        const std::vector<GeomField>& fields() const { return m_fields; }
+
+    private:
+
+        /// Label of data to mutate
+        QString m_label;
+        /// Total number of loaded points
+        size_t m_npoints;
+        /// Position offset
+        V3d m_offset;
+        /// Point data field storage
+        std::vector<GeomField> m_fields;
+        /// An index field is required, plus an alias for convenience:
+        int m_indexFieldIdx;
+        size_t* m_index;
+};
+
+Q_DECLARE_METATYPE(std::shared_ptr<GeometryMutator>)
+
+#endif // DISPLAZ_GEOMETRYMUTATOR_H_INCLUDED

--- a/src/render/GeometryMutator.h
+++ b/src/render/GeometryMutator.h
@@ -57,7 +57,7 @@ class GeometryMutator : public QObject
         std::vector<GeomField> m_fields;
         /// An index field is required, plus an alias for convenience:
         int m_indexFieldIdx;
-        uint* m_index;
+        uint32_t* m_index;
 };
 
 Q_DECLARE_METATYPE(std::shared_ptr<GeometryMutator>)

--- a/src/render/GeometryMutator.h
+++ b/src/render/GeometryMutator.h
@@ -40,7 +40,7 @@ class GeometryMutator : public QObject
         size_t pointCount() const { return m_npoints; }
 
         /// Get index of points to mutate
-        int* index() const { return m_index; }
+        uint* index() const { return m_index; }
 
         /// Get fields to mutate
         const std::vector<GeomField>& fields() const { return m_fields; }
@@ -57,7 +57,7 @@ class GeometryMutator : public QObject
         std::vector<GeomField> m_fields;
         /// An index field is required, plus an alias for convenience:
         int m_indexFieldIdx;
-        int* m_index;
+        uint* m_index;
 };
 
 Q_DECLARE_METATYPE(std::shared_ptr<GeometryMutator>)

--- a/src/render/GeometryMutator.h
+++ b/src/render/GeometryMutator.h
@@ -42,6 +42,9 @@ class GeometryMutator : public QObject
         /// Get index of points to mutate
         uint32_t* index() const { return m_index; }
 
+        /// Return offset applied to "position" field.
+        const V3d& offset() const { return m_offset; }
+
         /// Get fields to mutate
         const std::vector<GeomField>& fields() const { return m_fields; }
 

--- a/src/render/GeometryMutator.h
+++ b/src/render/GeometryMutator.h
@@ -40,7 +40,7 @@ class GeometryMutator : public QObject
         size_t pointCount() const { return m_npoints; }
 
         /// Get index of points to mutate
-        uint* index() const { return m_index; }
+        uint32_t* index() const { return m_index; }
 
         /// Get fields to mutate
         const std::vector<GeomField>& fields() const { return m_fields; }

--- a/src/render/GeometryMutator.h
+++ b/src/render/GeometryMutator.h
@@ -40,7 +40,7 @@ class GeometryMutator : public QObject
         size_t pointCount() const { return m_npoints; }
 
         /// Get index of points to mutate
-        size_t* index() const { return m_index; }
+        int* index() const { return m_index; }
 
         /// Get fields to mutate
         const std::vector<GeomField>& fields() const { return m_fields; }
@@ -57,7 +57,7 @@ class GeometryMutator : public QObject
         std::vector<GeomField> m_fields;
         /// An index field is required, plus an alias for convenience:
         int m_indexFieldIdx;
-        size_t* m_index;
+        int* m_index;
 };
 
 Q_DECLARE_METATYPE(std::shared_ptr<GeometryMutator>)

--- a/src/render/PointArray.cpp
+++ b/src/render/PointArray.cpp
@@ -405,12 +405,25 @@ void PointArray::mutate(std::shared_ptr<GeometryMutator> mutator)
     const std::vector<GeomField>& mut_fields = mutator->fields();
     auto mut_idx = mutator->index();
 
+    // Check index is valid
+    for (size_t j = 0; j < npoints; ++j)
+    {
+        if (mut_idx[j] < 0 || mut_idx[j] >= m_npoints)
+        {
+            g_logger.error("Index out of bounds - got %d (should be between zero and %d)", mut_idx[j], m_npoints-1);
+            return;
+        }
+    }
+
     // Currently doesn't matter if a field isn't found
     // Convenient way to ignore "index" but is not robust
-    for (size_t field_idx = 0; field_idx < m_fields.size(); ++field_idx)
+    for (size_t mut_field_idx = 0; mut_field_idx < mut_fields.size(); ++mut_field_idx)
     {
-        for (size_t mut_field_idx = 0; mut_field_idx < mut_fields.size(); ++mut_field_idx)
+        for (size_t field_idx = 0; field_idx < m_fields.size(); ++field_idx)
         {
+            if (mut_fields[mut_field_idx].name == "Index")
+                continue;
+
             if (m_fields[field_idx].name == mut_fields[mut_field_idx].name &&
                 m_fields[field_idx].spec == mut_fields[mut_field_idx].spec)
             {
@@ -425,6 +438,8 @@ void PointArray::mutate(std::shared_ptr<GeometryMutator> mutator)
                 break;
             }
         }
+
+        g_logger.warning("Didn't encounter a field labeled \"%s\"", mut_fields[mut_field_idx].name);
     }
 }
 

--- a/src/render/PointArray.cpp
+++ b/src/render/PointArray.cpp
@@ -368,9 +368,9 @@ bool PointArray::loadFile(QString fileName, size_t maxPointCount)
 
     // Sort points into octree order
     emit loadStepStarted("Sorting points");
-    std::unique_ptr<size_t[]> inds(new size_t[m_npoints]);
+    m_inds = std::unique_ptr<size_t[]>(new size_t[m_npoints]);
     for (size_t i = 0; i < m_npoints; ++i)
-        inds[i] = i;
+        m_inds[i] = i;
     // Expand the bound so that it's cubic.  Not exactly sure it's required
     // here, but cubic nodes sometimes work better the points are better
     // distributed for LoD, splitting is unbiased, etc.
@@ -378,14 +378,14 @@ bool PointArray::loadFile(QString fileName, size_t maxPointCount)
     V3f diag = rootBound.size();
     float rootRadius = std::max(std::max(diag.x, diag.y), diag.z) / 2;
     ProgressFunc progressFunc(*this);
-    m_rootNode.reset(makeTree(0, &inds[0], 0, m_npoints, &m_P[0],
+    m_rootNode.reset(makeTree(0, &m_inds[0], 0, m_npoints, &m_P[0],
                               rootBound.center(), rootRadius, progressFunc));
     // Reorder point fields into octree order
     emit loadStepStarted("Reordering fields");
     for (size_t i = 0; i < m_fields.size(); ++i)
     {
         g_logger.debug("Reordering field %d: %s", i, m_fields[i]);
-        reorder(m_fields[i], inds.get(), m_npoints);
+        reorder(m_fields[i], m_inds.get(), m_npoints);
         emit loadProgress(int(100*(i+1)/m_fields.size()));
     }
     m_P = (V3f*)m_fields[m_positionFieldIdx].as<float>();

--- a/src/render/PointArray.cpp
+++ b/src/render/PointArray.cpp
@@ -405,6 +405,12 @@ void PointArray::mutate(std::shared_ptr<GeometryMutator> mutator)
     const std::vector<GeomField>& mut_fields = mutator->fields();
     auto mut_idx = mutator->index();
 
+    if (m_npoints > 4294967296)
+    {
+        g_logger.error("Mutation with more than 2^32 points is not supported");
+        return;
+    }
+
     // Check index is valid
     for (size_t j = 0; j < npoints; ++j)
     {

--- a/src/render/PointArray.cpp
+++ b/src/render/PointArray.cpp
@@ -385,7 +385,7 @@ bool PointArray::loadFile(QString fileName, size_t maxPointCount)
     for (size_t i = 0; i < m_fields.size(); ++i)
     {
         g_logger.debug("Reordering field %d: %s", i, m_fields[i]);
-        reorder(m_fields[i], m_inds.get(), m_npoints);
+        reorder(m_fields[i], inds.get(), m_npoints);
         emit loadProgress(int(100*(i+1)/(m_fields.size()+1))); // denominator +1 for permutation reorder below
     }
     m_P = (V3f*)m_fields[m_positionFieldIdx].as<float>();

--- a/src/render/PointArray.h
+++ b/src/render/PointArray.h
@@ -83,6 +83,7 @@ class PointArray : public Geometry
         /// A position field is required.  Alias for convenience:
         int m_positionFieldIdx;
         V3f* m_P;
+        std::unique_ptr<size_t[]> m_inds;
 };
 
 

--- a/src/render/PointArray.h
+++ b/src/render/PointArray.h
@@ -62,18 +62,15 @@ class PointArray : public Geometry
     private:
         bool loadLas(QString fileName, size_t maxPointCount,
                      std::vector<GeomField>& fields, V3d& offset,
-                     size_t& npoints, uint64_t& totalPoints,
-                     Imath::Box3d& bbox, V3d& centroid);
+                     size_t& npoints, uint64_t& totalPoints);
 
         bool loadText(QString fileName, size_t maxPointCount,
                       std::vector<GeomField>& fields, V3d& offset,
-                      size_t& npoints, uint64_t& totalPoints,
-                      Imath::Box3d& bbox, V3d& centroid);
+                      size_t& npoints, uint64_t& totalPoints);
 
         bool loadPly(QString fileName, size_t maxPointCount,
                      std::vector<GeomField>& fields, V3d& offset,
-                     size_t& npoints, uint64_t& totalPoints,
-                     Imath::Box3d& bbox, V3d& centroid);
+                     size_t& npoints, uint64_t& totalPoints);
 
         friend struct ProgressFunc;
 

--- a/src/render/PointArray.h
+++ b/src/render/PointArray.h
@@ -12,6 +12,7 @@
 #include "Geometry.h"
 #include "typespec.h"
 #include "geomfield.h"
+#include "GeometryMutator.h"
 
 class QGLShaderProgram;
 
@@ -30,6 +31,8 @@ class PointArray : public Geometry
 
         // Overridden Geometry functions
         virtual bool loadFile(QString fileName, size_t maxVertexCount);
+
+        virtual void mutate(std::shared_ptr<GeometryMutator> mutator);
 
         virtual void draw(const TransformState& transState, double quality) const;
 

--- a/src/render/PointArray.h
+++ b/src/render/PointArray.h
@@ -86,7 +86,7 @@ class PointArray : public Geometry
         /// A position field is required.  Alias for convenience:
         int m_positionFieldIdx;
         V3f* m_P;
-        std::unique_ptr<size_t[]> m_inds;
+        std::unique_ptr<uint32_t[]> m_inds;
 };
 
 

--- a/src/typespec.h
+++ b/src/typespec.h
@@ -66,9 +66,11 @@ struct TypeSpec
     static TypeSpec vec3float32() { return TypeSpec(Float, 4, 3, Vector); }
     static TypeSpec float32() { return TypeSpec(Float, 4, 1); }
     // Non-scaled integers
+    static TypeSpec uint32_i()  { return TypeSpec(Uint, 4, 1, Array, false); }
     static TypeSpec uint16_i()  { return TypeSpec(Uint, 2, 1, Array, false); }
     static TypeSpec uint8_i()   { return TypeSpec(Uint, 1, 1, Array, false); }
     // Scaled fixed point integers
+    static TypeSpec uint32()  { return TypeSpec(Uint, 4, 1); }
     static TypeSpec uint16()  { return TypeSpec(Uint, 2, 1); }
     static TypeSpec uint8()   { return TypeSpec(Uint, 1, 1); }
 
@@ -81,7 +83,7 @@ struct TypeSpec
 
     /// Get number of bytes required to store the field for a single point
     int size() const { return elsize*count; }
-
+    /// Check that two TypeSpecs are exactly equal
     bool operator==(const TypeSpec& other) const
     {
         return type == other.type && elsize == other.elsize &&

--- a/src/typespec.h
+++ b/src/typespec.h
@@ -81,6 +81,13 @@ struct TypeSpec
 
     /// Get number of bytes required to store the field for a single point
     int size() const { return elsize*count; }
+
+    bool operator==(const TypeSpec& other) const
+    {
+        return type == other.type && elsize == other.elsize &&
+            count == other.count && semantics == other.semantics &&
+            fixedPoint == other.fixedPoint;
+    }
 };
 
 


### PR DESCRIPTION
This is WIP towards an implementation of #133. The idea is to let users change a subset of vertex properties on a subset of verticies, making the IPC much faster for complex and rich scripting applications.

The first commit will allow us to use the original indices to refer to only a subset of points which we wish to modify, but takes slightly more RAM by default. The next steps, as I see them, will be

 * Create a new `GeometryMutator` class that loads a (specially tagged?) .ply file.
 * When the `GeometryMutator` is passed to the main thread, it must search for data of the same label and ask `GeometryMutator` to mutate it.
 * Set up the CLI