### PR TITLE
Resolve Coverity UMR - HookFormatter::m_eventId uninitialised

### DIFF
--- a/src/HookFormatter.cpp
+++ b/src/HookFormatter.cpp
@@ -12,7 +12,8 @@ HookFormatter::HookFormatter(PointViewerMainWindow* getPayload, QByteArray hookS
     : QObject(parent),
     m_hookSpec(hookSpec),
     m_hookPayload(hookPayload),
-    m_getPayload(getPayload)
+    m_getPayload(getPayload),
+    m_eventId(0)
 {
     connect(this, SIGNAL(sendIpcMessage(QByteArray)), parent, SLOT(sendMessage(QByteArray)));
     connect(parent, SIGNAL(disconnected()), this, SLOT(channelDisconnected()));


### PR DESCRIPTION
![hookformatter](https://cloud.githubusercontent.com/assets/545677/19010127/f8f2f4f0-87be-11e6-9c54-5206209f2eee.PNG)
