### PR TITLE
Bugfix: correctly attach textures to shader uniforms

### DIFF
--- a/src/render/View3D.cpp
+++ b/src/render/View3D.cpp
@@ -796,10 +796,10 @@ void View3D::drawAxes() const
     {
         QGLShaderProgram& axesBackgroundShader = m_axesBackgroundShader->shaderProgram();
         GLint textureSampler = glGetUniformLocation(axesBackgroundShader.programId(), "texture0");
-        // texture
-        m_drawAxesBackground.bind(textureSampler);
         // shader
         axesBackgroundShader.bind();
+        // texture
+        m_drawAxesBackground.bind(textureSampler);
         // vertex buffer
         glBindVertexArray(m_quadVertexArray);
         // matrix stack
@@ -852,10 +852,9 @@ void View3D::drawAxes() const
     if (m_axesLabelShader->isValid())
     {
         QGLShaderProgram& axesLabelShader = m_axesLabelShader->shaderProgram();
-        GLint textureSampler = glGetUniformLocation(axesLabelShader.programId(), "texture0");
-
         // shader
         axesLabelShader.bind();
+        GLint texLocation = glGetUniformLocation(axesLabelShader.programId(), "texture0");
         // vertex buffer
         glBindVertexArray(m_quadLabelVertexArray);
         // matrix stack
@@ -865,17 +864,17 @@ void View3D::drawAxes() const
         // offset
         axesLabelShader.setUniformValue("offset", px.x, px.y, px.z);
         // texture
-        m_drawAxesLabelX.bind(textureSampler);
+        m_drawAxesLabelX.bind(texLocation);
         // draw
         glDrawArrays( GL_TRIANGLES, 0, 6 );
         axesLabelShader.setUniformValue("offset", py.x, py.y, py.z);
         // texture
-        m_drawAxesLabelY.bind(textureSampler);
+        m_drawAxesLabelY.bind(texLocation);
         // draw
         glDrawArrays( GL_TRIANGLES, 0, 6 );
         axesLabelShader.setUniformValue("offset", pz.x, pz.y, pz.z);
         // texture
-        m_drawAxesLabelZ.bind(textureSampler);
+        m_drawAxesLabelZ.bind(texLocation);
         // draw
         glDrawArrays( GL_TRIANGLES, 0, 6 );
         // do NOT release shader, this is no longer supported in OpenGL 3.2

--- a/src/render/glutil.h
+++ b/src/render/glutil.h
@@ -298,8 +298,16 @@ public:
         }
     }
 
-    void bind(int sampler) const
+    /// Bind a glsl sampler location to a given texture unit.
+    ///
+    /// `samplerLocation` should be the location of a sampler variable in the
+    /// shader, as determined via glGetUniformLocation().
+    ///
+    /// `textureUnit` is the unit which will be used; textures in simultaneous
+    /// use must be assigned to distinct texture units.
+    void bind(int samplerLocation, int textureUnit = 0) const
     {
+        glActiveTexture(GL_TEXTURE0 + textureUnit);
         if (!m_texture)
         {
             glGenTextures(1, &m_texture);
@@ -315,12 +323,9 @@ public:
         {
             glBindTexture(m_target, m_texture);
         }
-        // TODO: this has to become more sophisticated, if we ever want to have
-        // more than one texture bound
-        glActiveTexture(GL_TEXTURE0);
-        if (sampler >= 0)
+        if (samplerLocation >= 0)
         {
-            glBindSampler(m_texture, sampler);
+            glUniform1i(samplerLocation, textureUnit);
         }
     }
 


### PR DESCRIPTION
We're not using separate sampler objects explicitly, so the usage of
glBindSampler() was just wrong, as reported by apitrace.  Correct this
by using glUniform1i instead.  Also add minor generalization so that
more than one texture may be used in a given shader.

Fixes #150