### PR TITLE
Replace .has_key for python bindings

### DIFF
--- a/bindings/python/displaz.py
+++ b/bindings/python/displaz.py
@@ -25,9 +25,9 @@ def _interpret_spec(specstr):
     }
     spec = {}
     for c in specstr:
-        if colors.has_key(c):
+        if c in colors:
             spec['color'] = np.array(colors[c], dtype=np.float32)
-        elif markershapes.has_key(c):
+        elif c in markershapes:
             spec['markershape'] = np.array(markershapes[c], dtype=np.int32)
         else:
             raise Exception('Plot spec %s not recognized' % (c,))


### PR DESCRIPTION
dict.has_key is only available in python2.x, the `key in dict` syntax is
available in python2.3 and later. This should allow the python bindings
to work for more versions.