### PR TITLE
Fixed "undefined reference to qt_version_tag" on Ubuntu 16.10

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -186,9 +186,9 @@ else()
         set_target_properties(displaz-gui PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
     endif()
     if (UNIX)
-        # TODO this is a workaround for Ubuntu 16.04 x86-64
+        # TODO this is a workaround for Ubuntu 16.04 x86-64 to fix issue #87
         add_definitions(-fPIC)
-        # TODO this is a workaround for Ubuntu 16.10 x86-64
+        # TODO this is a workaround for Ubuntu 16.10 x86-64 to fix issue #158
         add_definitions(-DQT_NO_VERSION_TAGGING)
     endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -185,9 +185,11 @@ else()
     if (Qt5_POSITION_INDEPENDENT_CODE)
         set_target_properties(displaz-gui PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
     endif()
-    # TODO this is a workaround for Ubuntu 16.04 x86-64
     if (UNIX)
+        # TODO this is a workaround for Ubuntu 16.04 x86-64
         add_definitions(-fPIC)
+        # TODO this is a workaround for Ubuntu 16.10 x86-64
+        add_definitions(-DQT_NO_VERSION_TAGGING)
     endif()
 endif()
 


### PR DESCRIPTION
Fixes issue #158.

I'm not sure what side effects this switch could have when building on other linux distros.