### PR TITLE
Include sys/stat.h to fix build on OpenBSD

### DIFF
--- a/src/InterProcessLock.cpp
+++ b/src/InterProcessLock.cpp
@@ -13,6 +13,7 @@
 #else
 #   include <unistd.h>
 #   include <sys/file.h> // flock()
+#   include <sys/stat.h> // S_IWUSR defines
 #   include <string.h>   // strerror()
 #endif
 


### PR DESCRIPTION
I've been able to build displaz on OpenBSD, using a bit of cmake magic to find the GL headers in usr/X11R6/include - and all i needed was this oneliner.

sadly, the log window says at startup:
```
OpenGL implementation:
  GL_VENDOR    = X.Org
  GL_RENDERER  = Gallium 0.4 on AMD RV610 (DRM 2.29.0 / 6.0)
  GL_VERSION   = 3.1 (Core Profile) Mesa 13.0.2
  GLSL_VERSION = 1.40
  GLEW_VERSION = 2.0.0
ERROR: Could not read cursor shader.
ERROR: Could not read axes shaders
ERROR: Could not read grid shader.
ERROR: Couldn't open shader file "shaders:las_points.glsl": No such file or directory
```
I can open a las file, but it wont display:
```
Loaded 1018103 of 1018103 points from file /tmp/10651_CRAIG_SemisLidar_L93-IGN69_694500_6511250.las in 0.81 seconds
```
What could be missing ?