### PR TITLE
Bugfix: V3d for bounding box offset to avoid draw quantization errors

### DIFF
--- a/src/render/glutil.cpp
+++ b/src/render/glutil.cpp
@@ -93,7 +93,7 @@ void drawBox(const TransformState& transState,
 
 void drawBoundingBox(const TransformState& transState,
                      const GLuint& bboxVertexArray,
-                     const Imath::V3f& offset,
+                     const Imath::V3d& offset,
                      const Imath::C3f& col,
                      const GLuint& shaderProgram)
 {

--- a/src/render/glutil.h
+++ b/src/render/glutil.h
@@ -95,7 +95,7 @@ void drawBox(const TransformState& transState,
 void drawBox(const TransformState& transState,
              const Imath::Box3f& bbox, const Imath::C3f& col, const GLuint& shaderProgram);
 void drawBoundingBox(const TransformState& transState, const GLuint& bboxVertexArray,
-                     const Imath::V3f& offset, const Imath::C3f& col, const GLuint& shaderProgram);
+                     const Imath::V3d& offset, const Imath::C3f& col, const GLuint& shaderProgram);
 
 /// Draw a sphere using the given shader.  May be semitransparent.
 ///


### PR DESCRIPTION
When using V3f, the bounding box position will be quantized to float32
precision far from the origin, resulting in visual errors where a
dataset doesn't fit within its supposed bounding box.