### PR TITLE
Fix appveyor build for Windows packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,12 +162,12 @@ find_program(RST2HTML NAMES rst2html rst2html.py)
 if (RST2HTML)
     set (readmeHtml ${PROJECT_BINARY_DIR}/README.html)
     add_custom_command(OUTPUT ${readmeHtml}
-        COMMAND python ${RST2HTML} ${PROJECT_SOURCE_DIR}/README.rst ${readmeHtml}
+        COMMAND ${RST2HTML} ${PROJECT_SOURCE_DIR}/README.rst ${readmeHtml}
         DEPENDS README.rst
     )
     set (userguideHtml ${PROJECT_BINARY_DIR}/userguide.html)
     add_custom_command(OUTPUT ${userguideHtml}
-        COMMAND python ${RST2HTML} ${PROJECT_SOURCE_DIR}/doc/userguide.rst ${userguideHtml}
+        COMMAND ${RST2HTML} ${PROJECT_SOURCE_DIR}/doc/userguide.rst ${userguideHtml}
         DEPENDS doc/userguide.rst
     )
     add_custom_target(doc ALL DEPENDS ${readmeHtml} ${userguideHtml})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,12 +162,12 @@ find_program(RST2HTML NAMES rst2html rst2html.py)
 if (RST2HTML)
     set (readmeHtml ${PROJECT_BINARY_DIR}/README.html)
     add_custom_command(OUTPUT ${readmeHtml}
-        COMMAND ${RST2HTML} ${PROJECT_SOURCE_DIR}/README.rst ${readmeHtml}
+        COMMAND python ${RST2HTML} ${PROJECT_SOURCE_DIR}/README.rst ${readmeHtml}
         DEPENDS README.rst
     )
     set (userguideHtml ${PROJECT_BINARY_DIR}/userguide.html)
     add_custom_command(OUTPUT ${userguideHtml}
-        COMMAND ${RST2HTML} ${PROJECT_SOURCE_DIR}/doc/userguide.rst ${userguideHtml}
+        COMMAND python ${RST2HTML} ${PROJECT_SOURCE_DIR}/doc/userguide.rst ${userguideHtml}
         DEPENDS doc/userguide.rst
     )
     add_custom_target(doc ALL DEPENDS ${readmeHtml} ${userguideHtml})

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,8 @@ branches:
 # scripts that are called at very beginning, before repo cloning
 init:
   - git config --global core.autocrlf input
-
+  - set QTDIR=C:\Qt\5.6\msvc2015_64
+  - set PATH=%PATH%;%QTDIR%\bin
 # scripts that run after cloning repository
 #install:
 #  - Install rst2html for docs?
@@ -52,7 +53,7 @@ build_script:
   - echo Build displaz:
   - mkdir build
   - cd build
-  - cmake -G "%COMPILER%" -D CMAKE_PREFIX_PATH=C:\Qt\5.6\msvc2015_64 -DDISPLAZ_BUILD_NUMBER=%APPVEYOR_BUILD_NUMBER% ..
+  - cmake -G "%COMPILER%" -D CMAKE_PREFIX_PATH=C:\Qt\5.6\msvc2015_64 -D DISPLAZ_BUILD_NUMBER=%APPVEYOR_BUILD_NUMBER% ..
   - cmake --build . --config %CONFIGURATION%
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ branches:
 init:
   - git config --global core.autocrlf input
   - set QTDIR=C:\Qt\5.6\msvc2015_64
-  - set PATH=%PATH%;%QTDIR%\bin
+  - set PATH=%QTDIR%\bin;%PATH%
 # scripts that run after cloning repository
 #install:
 #  - Install rst2html for docs?

--- a/cmake/DeployQt5.cmake
+++ b/cmake/DeployQt5.cmake
@@ -324,7 +324,7 @@ function(install_qt5_executable executable)
       get_property(loc TARGET Qt5::QWindowsIntegrationPlugin
         PROPERTY LOCATION_RELEASE)
       install_qt5_plugin("${loc}" "${executable}" 0 installed_plugin_paths
-        "platforms" "${component}")
+        "${component}")
       list(APPEND libs ${installed_plugin_paths})
     endif()
     foreach(plugin ${qtplugins})

--- a/src/render/View3D.cpp
+++ b/src/render/View3D.cpp
@@ -194,6 +194,7 @@ void View3D::removeAnnotations(const QRegExp& labelRegex)
             annotations.append(annotation);
     }
     m_annotations = annotations;
+    restartRender();
 }
 
 


### PR DESCRIPTION
Removed extra platform folder in packaging
Set path to include Qt, so packaging can find Qt dlls

This PR includes c42f:fix-windows-package

See my build https://ci.appveyor.com/project/evetion/displaz/build/1