### PR TITLE
Add support for fractional scaling

### DIFF
--- a/src/render/View3D.cpp
+++ b/src/render/View3D.cpp
@@ -267,6 +267,8 @@ double View3D::getDevicePixelRatio()
 {
 #ifdef DISPLAZ_USE_QT4
     return 1.0;
+#elif QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+    return devicePixelRatioF();
 #else
     return devicePixelRatio();
 #endif


### PR DESCRIPTION
While testing this project on KDE, I found that the View3D did not scale correctly to my HiDPI settings (which are set to 1.5). The reason for this issue is that `devicePixelRatio() `only returns integer values, which means a scaling of 1.5 will round down to 1. After a bit of research, I found out that Qt can obtain the fractional scaling ratio with `devicePixelRatioF()` since Qt 5.6.

This commit implements the following changes:

-  If Qt version is greater or equal than 5.6, then the `getDevicePixelRatio()` will return the value of `devicePixelRatioF()`.
- Otherwise, `getDevicePixelRatio()` will return `devicePixelRatio()` on Qt 5 and 1.0 on Qt 4.

Below are some screenshots to better explain the changes in this PR.

**Before**
![screenshot_20180318_220628](https://user-images.githubusercontent.com/4225542/37577762-b1c84514-2af9-11e8-8f23-3afd4bba784e.png)

**After**
![screenshot_20180318_220706](https://user-images.githubusercontent.com/4225542/37577782-cc37140c-2af9-11e8-881a-19f8e0b57763.png)

Greetings!


