### PR TITLE
Formulate intensity tone mapping as Middle/Contrast

### DIFF
--- a/shaders/las_points.glsl
+++ b/shaders/las_points.glsl
@@ -9,12 +9,13 @@ uniform mat4 modelViewProjectionMatrix;
 //------------------------------------------------------------------------------
 #if defined(VERTEX_SHADER)
 
-uniform float pointRadius = 0.1;   //# uiname=Point Radius; min=0.001; max=10
-uniform float trimRadius = 1000000;//# uiname=Trim Radius; min=1; max=1000000
-uniform float exposure = 1.0;      //# uiname=Exposure; min=0.001; max=10000
-uniform float contrast = 1.0;      //# uiname=Contrast; min=0.001; max=10000
-uniform int colorMode = 0;         //# uiname=Colour Mode; enum=Intensity|Colour|Return Index|Point Source|Las Classification|File Number
-uniform int selectionMode = 0;     //# uiname=Selection; enum=All|Classified|First Return|Last Return|First Of Several
+uniform float pointRadius = 0.1;    //# uiname=Point Radius; min=0.001; max=10
+uniform float trimRadius = 1000000; //# uiname=Trim Radius; min=1; max=1000000
+uniform float reference = 400.0;    //# uiname=Reference Intensity; min=0.001; max=100000
+uniform float exposure = 1.0;       //# uiname=Exposure; min=0.001; max=10000
+uniform float contrast = 1.0;       //# uiname=Contrast; min=0.001; max=10000
+uniform int colorMode = 0;          //# uiname=Colour Mode; enum=Intensity|Colour|Return Index|Point Source|Las Classification|File Number
+uniform int selectionMode = 0;      //# uiname=Selection; enum=All|Classified|First Return|Last Return|First Of Several
 uniform float minPointSize = 0;
 uniform float maxPointSize = 400.0;
 // Point size multiplier to get from a width in projected coordinates to the
@@ -36,9 +37,9 @@ flat out float pointScreenSize;
 flat out vec3 pointColor;
 flat out int markerShape;
 
-float tonemap(float x, float exposure, float contrast)
+float tonemap(float x, float reference, float contrast)
 {
-    float Y = pow(exposure*x, contrast);
+    float Y = pow(x/reference, contrast);
     Y = Y / (1.0 + Y);
     return Y;
 }
@@ -67,7 +68,7 @@ void main()
     markerShape = 1;
     // Compute vertex color
     if (colorMode == 0)
-        pointColor = tonemap(intensity/400.0, exposure, contrast) * vec3(1);
+        pointColor = tonemap(intensity, reference, contrast) * vec3(1);
     else if (colorMode == 1)
         pointColor = contrast*(exposure*color - vec3(0.5)) + vec3(0.5);
     else if (colorMode == 2)


### PR DESCRIPTION
For mapping intensity values to greyscale we currently specify an _exposure_ which is internally divided by 400.0.

For improved intuition, expose _middle_ intensity (default 400.0) which is the intensity value that will map to 50% output greyscale.

This _middle_ parameter is something we'd like to use elsewhere, indicating the expected range of intensity for some particular sensor.