### PR TITLE
Qt5 Linux build fix

### DIFF
--- a/src/render/Annotation.cpp
+++ b/src/render/Annotation.cpp
@@ -10,6 +10,7 @@
 #include <QColor>
 #include <QImage>
 #include <QPainter>
+#include <QPainterPath>
 
 /// Creates and returns a texture containing some text.
 static std::unique_ptr<Texture> makeTextureFromText(const QString& text)


### PR DESCRIPTION
Fixes this error.
```
displaz/src/render/Annotation.cpp:22:30: warning: ‘int QFontMetrics::width(const QString&, int) const’ is deprecated: Use QFontMetrics::horizontalAdvance [-Wdeprecated-declarations]
   22 |     int width = fm.width(text);
```