### PR TITLE
Fix OpenGL linking with GLVND

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,7 +175,7 @@ else()
     target_link_libraries(displaz
         Qt5::Core Qt5::Gui Qt5::OpenGL
         Qt5::Network Qt5::Widgets
-        ${OPENGL_gl_LIBRARY} ${GLEW_LIBRARIES}
+        OpenGL::GL ${GLEW_LIBRARIES}
         ${ILMBASE_LIBRARIES}
     )
     if (TARGET displaz_com)


### PR DESCRIPTION
On GLVND systems, building with `OpenGL_GL_PREFERENCE=GLVND` would fail during the linking steps, as CMake would try to link the hardcoded GLX library locations, as opposed to the imported targets which CMake recommends.

Fix this by linking the imported target (at least for the case where I could test it, i.e. Qt5 systems.)