### PR TITLE
Reorganised shader classes into shader subdirectory, C++17 variant, get/set parameters

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ include_directories(BEFORE
     .
     gui
     render
+    shader
     ../thirdparty
     ${GLEW_INCLUDE_DIR}
     ${OPENGL_INCLUDE_DIR}
@@ -64,8 +65,9 @@ displaz_qt_wrap_cpp(gui_moc_srcs
     render/HCloudView.h
     render/View3D.h
     render/PointArray.h
-    render/Shader.h
     render/GeometryMutator.h
+
+    shader/ShaderProgram.h
 )
 
 set(gui_srcs
@@ -94,9 +96,11 @@ set(gui_srcs
     render/TriMesh.cpp
     render/PointArray.cpp
     render/View3D.cpp
-    render/Shader.cpp
     render/GeometryMutator.cpp
     render/Annotation.cpp
+
+    shader/Shader.cpp
+    shader/ShaderProgram.cpp
 
     ../thirdparty/rply/rply.c
     ../thirdparty/polypartition/polypartition.cpp

--- a/src/gui/PointViewerMainWindow.cpp
+++ b/src/gui/PointViewerMainWindow.cpp
@@ -13,6 +13,7 @@
 #include "TriMesh.h"
 #include "ShaderEditor.h"
 #include "Shader.h"
+#include "ShaderProgram.h"
 #include "View3D.h"
 #include "HookFormatter.h"
 #include "HookManager.h"

--- a/src/render/HCloudView.cpp
+++ b/src/render/HCloudView.cpp
@@ -10,6 +10,7 @@
 #include "glutil.h"
 #include "QtLogger.h"
 #include "Shader.h"
+#include "ShaderProgram.h"
 #include "streampagecache.h"
 #include "util.h"
 

--- a/src/render/View3D.cpp
+++ b/src/render/View3D.cpp
@@ -23,6 +23,7 @@
 #include "PointViewerMainWindow.h"
 #include "TriMesh.h"
 #include "Shader.h"
+#include "ShaderProgram.h"
 #include "tinyformat.h"
 #include "util.h"
 

--- a/src/shader/Shader.cpp
+++ b/src/shader/Shader.cpp
@@ -76,26 +76,22 @@ bool Shader::compileSourceCode(const QByteArray& src)
         if (!re.exactMatch(lines[lineIdx]))
             continue;
         QByteArray typeStr = re.cap(1).toUtf8().constData();
-        QVariant defaultValue;
-        ShaderParam::Type type;
+        ShaderParam::Variant defaultValue;
         if (typeStr == "float")
         {
-            type = ShaderParam::Float;
             defaultValue = re.cap(3).trimmed().toDouble();
         }
         else if (typeStr == "int")
         {
-            type = ShaderParam::Int;
             defaultValue = re.cap(3).trimmed().toInt();
         }
         else if (typeStr == "vec3")
         {
-            type = ShaderParam::Vec3;
             //defaultValue = re.cap(3).toDouble(); // FIXME
         }
         else
             continue;
-        ShaderParam param(type, re.cap(2).toUtf8().constData(), defaultValue);
+        ShaderParam param(re.cap(2).toUtf8().constData(), defaultValue);
         QMap<QString, QString>& kvPairs = param.kvPairs;
         QStringList pairList = re.cap(4).split(';');
         for (int i = 0; i < pairList.size(); ++i)

--- a/src/shader/Shader.cpp
+++ b/src/shader/Shader.cpp
@@ -1,0 +1,130 @@
+// Copyright 2015, Christopher J. Foster and the other displaz contributors.
+// Use of this code is governed by the BSD-style license found in LICENSE.txt
+
+#include "Shader.h"
+
+#include "tinyformat.h"
+#include "QtLogger.h"
+
+#include <QFormLayout>
+#include <QComboBox>
+
+
+/// Make shader #define flags for hardware or driver-dependent blacklisted
+/// features.  Current list:
+///
+/// BROKEN_GL_FRAG_COORD
+///
+static QByteArray makeBlacklistDefines()
+{
+    QByteArray defines;
+#   ifdef _WIN32
+    bool isIntel = false;
+    // Extremely useful list of GL_VENDOR strings seen in the wild:
+    // http://feedback.wildfiregames.com/report/opengl/feature/GL_VENDOR
+    QString vendorStr = (const char*)glGetString(GL_VENDOR);
+    if (vendorStr.contains("intel", Qt::CaseInsensitive))
+        isIntel = true;
+    // Blacklist use of gl_FragCoord/gl_FragDepth with Intel drivers on
+    // windows.  For some reason, this interacts badly with any use of
+    // gl_PointCoord, leading to gross rendering artifacts.
+    if (isIntel)
+        defines += "#define BROKEN_GL_FRAG_COORD\n";
+#endif
+    return defines;
+}
+
+
+//------------------------------------------------------------------------------
+// Shader implementation
+bool Shader::compileSourceCode(const QByteArray& src)
+{
+    // src may contain parts which are shared for various shader types - set up
+    // defines so we can tell which one we're compiling.
+    QByteArray defines;
+    switch (m_shader.shaderType())
+    {
+        case QGLShader::Vertex:   defines += "#define VERTEX_SHADER\n";   break;
+        case QGLShader::Fragment: defines += "#define FRAGMENT_SHADER\n"; break;
+    }
+    defines += makeBlacklistDefines();
+    QByteArray modifiedSrc = src;
+    // Add defines.  Some shader compilers require #version to come first (even
+    // before any #defines) so detect #version if it's present and put the
+    // defines after that.
+    int versionPos = src.indexOf("#version");
+    if (versionPos != -1)
+    {
+        int insertPos = src.indexOf('\n', versionPos);
+        if (insertPos == -1)
+            insertPos = src.length();
+        modifiedSrc.insert(insertPos+1, defines);
+    }
+    else
+    {
+        modifiedSrc = defines + src;
+    }
+    if (!m_shader.compileSourceCode(modifiedSrc))
+        return false;
+    m_source = src;
+    // Search source code looking for uniform variables
+    QStringList lines = QString(src).split('\n');
+    QRegExp re("uniform +([a-zA-Z_][a-zA-Z_0-9]*) +([a-zA-Z_][a-zA-Z_0-9]*) +=(.+); *//# *(.*)",
+               Qt::CaseSensitive, QRegExp::RegExp2);
+    for (int lineIdx = 0; lineIdx < lines.size(); ++lineIdx)
+    {
+        if (!re.exactMatch(lines[lineIdx]))
+            continue;
+        QByteArray typeStr = re.cap(1).toUtf8().constData();
+        QVariant defaultValue;
+        ShaderParam::Type type;
+        if (typeStr == "float")
+        {
+            type = ShaderParam::Float;
+            defaultValue = re.cap(3).trimmed().toDouble();
+        }
+        else if (typeStr == "int")
+        {
+            type = ShaderParam::Int;
+            defaultValue = re.cap(3).trimmed().toInt();
+        }
+        else if (typeStr == "vec3")
+        {
+            type = ShaderParam::Vec3;
+            //defaultValue = re.cap(3).toDouble(); // FIXME
+        }
+        else
+            continue;
+        ShaderParam param(type, re.cap(2).toUtf8().constData(), defaultValue);
+        QMap<QString, QString>& kvPairs = param.kvPairs;
+        QStringList pairList = re.cap(4).split(';');
+        for (int i = 0; i < pairList.size(); ++i)
+        {
+            QStringList keyAndVal = pairList[i].split('=');
+            if (keyAndVal.size() != 2)
+            {
+                g_logger.warning("Could not parse metadata \"%s\" for shader variable %s",
+                                 pairList[i].toStdString(), param.name.data());
+                continue;
+            }
+            kvPairs[keyAndVal[0].trimmed()] = keyAndVal[1].trimmed();
+        }
+        m_uniforms.push_back(param);
+    }
+    /*
+    // Debug: print out what we found
+    for (int i = 0; i < m_uniforms.size(); ++i)
+    {
+        tfm::printf("Found shader uniform \"%s\" with metadata\n",
+                    m_uniforms[i].name.data());
+        const QMap<QString, QString>& kvPairs = m_uniforms[i].kvPairs;
+        for (QMap<QString,QString>::const_iterator i = kvPairs.begin();
+             i != kvPairs.end(); ++i)
+        {
+            tfm::printf("  %s = \"%s\"\n", i.key().toStdString(),
+                        i.value().toStdString());
+        }
+    }
+    */
+    return true;
+}

--- a/src/shader/Shader.h
+++ b/src/shader/Shader.h
@@ -1,0 +1,49 @@
+// Copyright 2015, Christopher J. Foster and the other displaz contributors.
+// Use of this code is governed by the BSD-style license found in LICENSE.txt
+
+#ifndef SHADER_H_INCLUDED
+#define SHADER_H_INCLUDED
+
+#include <QList>
+#include <QByteArray>
+#include <QGLShader>
+
+#include "ShaderParam.h"
+
+/// Wrapper for QGLShader, with functionality added to parse
+/// the list of uniform parameters.
+class Shader
+{
+    public:
+        Shader(QGLShader::ShaderType type)
+            : m_shader(type)
+        { }
+
+        /// Return list of uniform shader parameters
+        const QList<ShaderParam>& uniforms() const
+        {
+            return m_uniforms;
+        }
+
+        /// Return original source code.
+        QByteArray sourceCode() const
+        {
+            return m_source;
+        }
+
+        /// Access to underlying shader
+        QGLShader* shader()
+        {
+            return &m_shader;
+        }
+
+        bool compileSourceCode(const QByteArray& src);
+
+    private:
+        QList<ShaderParam> m_uniforms;
+        QGLShader m_shader;  ///< Underlying shader
+        QByteArray m_source; ///< Non-mangled source code
+};
+
+
+#endif // SHADER_H_INCLUDED

--- a/src/shader/ShaderParam.h
+++ b/src/shader/ShaderParam.h
@@ -4,23 +4,21 @@
 #ifndef SHADER_PARAM_H_INCLUDED
 #define SHADER_PARAM_H_INCLUDED
 
+#include <variant>
+
 #include <QMap>
 #include <QString>
-#include <QVariant>
 #include <QByteArray>
+
+#include <Imath/ImathColor.h>
 
 /// Representation of a shader "parameter" (uniform variable or attribute)
 struct ShaderParam
 {
-    enum Type {
-        Float,
-        Int,
-        Vec3
-    };
+    using Variant = std::variant<double, int, Imath::C4c>;
 
-    Type type;             ///< Variable type
     QByteArray name;       ///< Name of the variable in the shader
-    QVariant defaultValue; ///< Default value
+    Variant defaultValue;  ///< Default value
     QMap<QString,QString> kvPairs; ///< name,value pairs with additional metadata
     int ordering;          ///< Ordering in source file
 
@@ -51,17 +49,19 @@ struct ShaderParam
         return val;
     }
 
-    ShaderParam(Type type=Float, QByteArray name="",
-                QVariant defaultValue = QVariant())
-        : type(type), name(name), defaultValue(defaultValue), ordering(0) {}
+    ShaderParam(QByteArray name="",
+                Variant defaultValue = Variant())
+        : name(name), defaultValue(defaultValue), ordering(0) {}
 };
 
 
 inline bool operator==(const ShaderParam& p1, const ShaderParam& p2)
 {
-    return p1.name == p2.name && p1.type == p2.type &&
-        p1.defaultValue == p2.defaultValue &&
-        p1.kvPairs == p2.kvPairs && p1.ordering == p2.ordering;
+    return
+        p1.name == p2.name &&
+        p1.defaultValue.index() == p2.defaultValue.index() &&
+        p1.kvPairs == p2.kvPairs &&
+        p1.ordering == p2.ordering;
 }
 
 
@@ -70,7 +70,7 @@ inline bool operator<(const ShaderParam& p1, const ShaderParam& p2)
 {
     if (p1.name != p2.name)
         return p1.name < p2.name;
-    return p1.type < p2.type;
+    return p1.defaultValue.index() < p2.defaultValue.index();
 }
 
 #endif // SHADER_PARAM_H_INCLUDED

--- a/src/shader/ShaderParam.h
+++ b/src/shader/ShaderParam.h
@@ -1,0 +1,76 @@
+// Copyright 2015, Christopher J. Foster and the other displaz contributors.
+// Use of this code is governed by the BSD-style license found in LICENSE.txt
+
+#ifndef SHADER_PARAM_H_INCLUDED
+#define SHADER_PARAM_H_INCLUDED
+
+#include <QMap>
+#include <QString>
+#include <QVariant>
+#include <QByteArray>
+
+/// Representation of a shader "parameter" (uniform variable or attribute)
+struct ShaderParam
+{
+    enum Type {
+        Float,
+        Int,
+        Vec3
+    };
+
+    Type type;             ///< Variable type
+    QByteArray name;       ///< Name of the variable in the shader
+    QVariant defaultValue; ///< Default value
+    QMap<QString,QString> kvPairs; ///< name,value pairs with additional metadata
+    int ordering;          ///< Ordering in source file
+
+    QString uiName() const
+    {
+        return kvPairs.value("uiname", name);
+    }
+
+    double getDouble(QString name, double defaultVal) const
+    {
+        if (!kvPairs.contains(name))
+            return defaultVal;
+        bool convOk = false;
+        double val = kvPairs[name].toDouble(&convOk);
+        if (!convOk)
+            return defaultVal;
+        return val;
+    }
+
+    int getInt(QString name, int defaultVal) const
+    {
+        if (!kvPairs.contains(name))
+            return defaultVal;
+        bool convOk = false;
+        double val = kvPairs[name].toInt(&convOk);
+        if (!convOk)
+            return defaultVal;
+        return val;
+    }
+
+    ShaderParam(Type type=Float, QByteArray name="",
+                QVariant defaultValue = QVariant())
+        : type(type), name(name), defaultValue(defaultValue), ordering(0) {}
+};
+
+
+inline bool operator==(const ShaderParam& p1, const ShaderParam& p2)
+{
+    return p1.name == p2.name && p1.type == p2.type &&
+        p1.defaultValue == p2.defaultValue &&
+        p1.kvPairs == p2.kvPairs && p1.ordering == p2.ordering;
+}
+
+
+// Operator for ordering in QMap
+inline bool operator<(const ShaderParam& p1, const ShaderParam& p2)
+{
+    if (p1.name != p2.name)
+        return p1.name < p2.name;
+    return p1.type < p2.type;
+}
+
+#endif // SHADER_PARAM_H_INCLUDED

--- a/src/shader/ShaderProgram.cpp
+++ b/src/shader/ShaderProgram.cpp
@@ -233,27 +233,43 @@ void ShaderProgram::setupParameters()
 
 void ShaderProgram::setUniforms()
 {
-    for (ParamMap::const_iterator i = m_params.begin();
-         i != m_params.end(); ++i)
+    for (ParamMap::const_iterator i = m_params.begin(); i != m_params.end(); ++i)
     {
-        const ShaderParam& param = i.key();
-        const ShaderParam::Variant& value = i.value();
-        switch (value.index())
-        {
-            case 0:
-                m_shaderProgram->setUniformValue(param.name.data(),
-                                                 (GLfloat) std::get<double>(value));
-                break;
-            case 1:
-                m_shaderProgram->setUniformValue(param.name.data(),
-                                                 (GLint) std::get<int>(value));
-                break;
-            case 2:
-                // FIXME
-                break;
-        }
+        setUniform(i.key().name.data(), i.value());
     }
 }
+
+
+void ShaderProgram::setUniform(const char *name, const ShaderParam::Variant& value)
+{
+    switch (value.index())
+    {
+        case 0:
+            m_shaderProgram->setUniformValue(name, (GLfloat) std::get<double>(value));
+            break;
+        case 1:
+            m_shaderProgram->setUniformValue(name, (GLint) std::get<int>(value));
+            break;
+        case 2:
+            // TODO
+            break;
+    }
+}
+
+
+bool ShaderProgram::getUniform(const char *name, ShaderParam::Variant& value)
+{
+    for (ParamMap::const_iterator i = m_params.begin(); i != m_params.end(); ++i)
+    {
+        if (i.key().name == QString(name))
+        {
+            value = i.value();
+            return true;
+        }
+    }
+    return false;
+}
+
 
 QByteArray ShaderProgram::shaderSource() const
 {

--- a/src/shader/ShaderProgram.cpp
+++ b/src/shader/ShaderProgram.cpp
@@ -1,7 +1,7 @@
 // Copyright 2015, Christopher J. Foster and the other displaz contributors.
 // Use of this code is governed by the BSD-style license found in LICENSE.txt
 
-#include "Shader.h"
+#include "ShaderProgram.h"
 
 #include "tinyformat.h"
 #include "DragSpinBox.h"
@@ -10,129 +10,6 @@
 #include <QFormLayout>
 #include <QComboBox>
 
-
-/// Make shader #define flags for hardware or driver-dependent blacklisted
-/// features.  Current list:
-///
-/// BROKEN_GL_FRAG_COORD
-///
-static QByteArray makeBlacklistDefines()
-{
-    QByteArray defines;
-#   ifdef _WIN32
-    bool isIntel = false;
-    // Extremely useful list of GL_VENDOR strings seen in the wild:
-    // http://feedback.wildfiregames.com/report/opengl/feature/GL_VENDOR
-    QString vendorStr = (const char*)glGetString(GL_VENDOR);
-    if (vendorStr.contains("intel", Qt::CaseInsensitive))
-        isIntel = true;
-    // Blacklist use of gl_FragCoord/gl_FragDepth with Intel drivers on
-    // windows.  For some reason, this interacts badly with any use of
-    // gl_PointCoord, leading to gross rendering artifacts.
-    if (isIntel)
-        defines += "#define BROKEN_GL_FRAG_COORD\n";
-#endif
-    return defines;
-}
-
-
-//------------------------------------------------------------------------------
-// Shader implementation
-bool Shader::compileSourceCode(const QByteArray& src)
-{
-    // src may contain parts which are shared for various shader types - set up
-    // defines so we can tell which one we're compiling.
-    QByteArray defines;
-    switch (m_shader.shaderType())
-    {
-        case QGLShader::Vertex:   defines += "#define VERTEX_SHADER\n";   break;
-        case QGLShader::Fragment: defines += "#define FRAGMENT_SHADER\n"; break;
-    }
-    defines += makeBlacklistDefines();
-    QByteArray modifiedSrc = src;
-    // Add defines.  Some shader compilers require #version to come first (even
-    // before any #defines) so detect #version if it's present and put the
-    // defines after that.
-    int versionPos = src.indexOf("#version");
-    if (versionPos != -1)
-    {
-        int insertPos = src.indexOf('\n', versionPos);
-        if (insertPos == -1)
-            insertPos = src.length();
-        modifiedSrc.insert(insertPos+1, defines);
-    }
-    else
-    {
-        modifiedSrc = defines + src;
-    }
-    if (!m_shader.compileSourceCode(modifiedSrc))
-        return false;
-    m_source = src;
-    // Search source code looking for uniform variables
-    QStringList lines = QString(src).split('\n');
-    QRegExp re("uniform +([a-zA-Z_][a-zA-Z_0-9]*) +([a-zA-Z_][a-zA-Z_0-9]*) +=(.+); *//# *(.*)",
-               Qt::CaseSensitive, QRegExp::RegExp2);
-    for (int lineIdx = 0; lineIdx < lines.size(); ++lineIdx)
-    {
-        if (!re.exactMatch(lines[lineIdx]))
-            continue;
-        QByteArray typeStr = re.cap(1).toUtf8().constData();
-        QVariant defaultValue;
-        ShaderParam::Type type;
-        if (typeStr == "float")
-        {
-            type = ShaderParam::Float;
-            defaultValue = re.cap(3).trimmed().toDouble();
-        }
-        else if (typeStr == "int")
-        {
-            type = ShaderParam::Int;
-            defaultValue = re.cap(3).trimmed().toInt();
-        }
-        else if (typeStr == "vec3")
-        {
-            type = ShaderParam::Vec3;
-            //defaultValue = re.cap(3).toDouble(); // FIXME
-        }
-        else
-            continue;
-        ShaderParam param(type, re.cap(2).toUtf8().constData(), defaultValue);
-        QMap<QString, QString>& kvPairs = param.kvPairs;
-        QStringList pairList = re.cap(4).split(';');
-        for (int i = 0; i < pairList.size(); ++i)
-        {
-            QStringList keyAndVal = pairList[i].split('=');
-            if (keyAndVal.size() != 2)
-            {
-                g_logger.warning("Could not parse metadata \"%s\" for shader variable %s",
-                                 pairList[i].toStdString(), param.name.data());
-                continue;
-            }
-            kvPairs[keyAndVal[0].trimmed()] = keyAndVal[1].trimmed();
-        }
-        m_uniforms.push_back(param);
-    }
-    /*
-    // Debug: print out what we found
-    for (int i = 0; i < m_uniforms.size(); ++i)
-    {
-        tfm::printf("Found shader uniform \"%s\" with metadata\n",
-                    m_uniforms[i].name.data());
-        const QMap<QString, QString>& kvPairs = m_uniforms[i].kvPairs;
-        for (QMap<QString,QString>::const_iterator i = kvPairs.begin();
-             i != kvPairs.end(); ++i)
-        {
-            tfm::printf("  %s = \"%s\"\n", i.key().toStdString(),
-                        i.value().toStdString());
-        }
-    }
-    */
-    return true;
-}
-
-
-//------------------------------------------------------------------------------
-// ShaderProgram implementation
 ShaderProgram::ShaderProgram(QObject* parent)
     : QObject(parent),
     m_pointSize(5),
@@ -148,6 +25,7 @@ bool paramOrderingLess(const QPair<ShaderParam,QVariant>& p1,
 {
     return p1.first.ordering < p2.first.ordering;
 }
+
 
 void ShaderProgram::setupParameterUI(QWidget* parentWidget)
 {
@@ -384,5 +262,4 @@ QByteArray ShaderProgram::shaderSource() const
         return QByteArray("");
     return m_vertexShader->sourceCode();
 }
-
 

--- a/src/shader/ShaderProgram.h
+++ b/src/shader/ShaderProgram.h
@@ -32,8 +32,13 @@ class ShaderProgram : public QObject
 
         /// Set up UI for the shader
         void setupParameterUI(QWidget* parentWidget);
+
         /// Send current uniform values to the underlying OpenGL shader
         void setUniforms();
+        /// Send uniform value to the underlying OpenGL shader
+        void setUniform(const char *name, const ShaderParam::Variant& value);
+        /// Get uniform value
+        bool getUniform(const char *name, ShaderParam::Variant& value);
 
         /// Read shader source from given file and call setShader()
         bool setShaderFromSourceFile(QString fileName);

--- a/src/shader/ShaderProgram.h
+++ b/src/shader/ShaderProgram.h
@@ -82,7 +82,7 @@ class ShaderProgram : public QObject
         double m_exposure;
         double m_contrast;
         int m_selector;
-        typedef QMap<ShaderParam,QVariant> ParamMap;
+        typedef QMap<ShaderParam,ShaderParam::Variant> ParamMap;
         ParamMap m_params;
         std::unique_ptr<Shader> m_vertexShader;
         std::unique_ptr<Shader> m_fragmentShader;

--- a/src/shader/ShaderProgram.h
+++ b/src/shader/ShaderProgram.h
@@ -1,115 +1,17 @@
 // Copyright 2015, Christopher J. Foster and the other displaz contributors.
 // Use of this code is governed by the BSD-style license found in LICENSE.txt
 
-#ifndef SHADER_H_INCLUDED
-#define SHADER_H_INCLUDED
+#ifndef SHADER_PROGRAM_H_INCLUDED
+#define SHADER_PROGRAM_H_INCLUDED
 
 #include <memory>
 
-#include <QMap>
-#include <QGLShader>
+#include <QObject>
+#include <QByteArray>
 #include <QGLShaderProgram>
 
-/// Representation of a shader "parameter" (uniform variable or attribute)
-struct ShaderParam
-{
-    enum Type {
-        Float,
-        Int,
-        Vec3
-    };
-
-    Type type;             ///< Variable type
-    QByteArray name;       ///< Name of the variable in the shader
-    QVariant defaultValue; ///< Default value
-    QMap<QString,QString> kvPairs; ///< name,value pairs with additional metadata
-    int ordering;          ///< Ordering in source file
-
-    QString uiName() const
-    {
-        return kvPairs.value("uiname", name);
-    }
-
-    double getDouble(QString name, double defaultVal) const
-    {
-        if (!kvPairs.contains(name))
-            return defaultVal;
-        bool convOk = false;
-        double val = kvPairs[name].toDouble(&convOk);
-        if (!convOk)
-            return defaultVal;
-        return val;
-    }
-
-    int getInt(QString name, int defaultVal) const
-    {
-        if (!kvPairs.contains(name))
-            return defaultVal;
-        bool convOk = false;
-        double val = kvPairs[name].toInt(&convOk);
-        if (!convOk)
-            return defaultVal;
-        return val;
-    }
-
-    ShaderParam(Type type=Float, QByteArray name="",
-                QVariant defaultValue = QVariant())
-        : type(type), name(name), defaultValue(defaultValue), ordering(0) {}
-};
-
-
-inline bool operator==(const ShaderParam& p1, const ShaderParam& p2)
-{
-    return p1.name == p2.name && p1.type == p2.type &&
-        p1.defaultValue == p2.defaultValue &&
-        p1.kvPairs == p2.kvPairs && p1.ordering == p2.ordering;
-}
-
-
-// Operator for ordering in QMap
-inline bool operator<(const ShaderParam& p1, const ShaderParam& p2)
-{
-    if (p1.name != p2.name)
-        return p1.name < p2.name;
-    return p1.type < p2.type;
-}
-
-
-/// Wrapper for QGLShader, with functionality added to parse
-/// the list of uniform parameters.
-class Shader
-{
-    public:
-        Shader(QGLShader::ShaderType type)
-            : m_shader(type)
-        { }
-
-        /// Return list of uniform shader parameters
-        const QList<ShaderParam>& uniforms() const
-        {
-            return m_uniforms;
-        }
-
-        /// Return original source code.
-        QByteArray sourceCode() const
-        {
-            return m_source;
-        }
-
-        /// Access to underlying shader
-        QGLShader* shader()
-        {
-            return &m_shader;
-        }
-
-        bool compileSourceCode(const QByteArray& src);
-
-    private:
-        QList<ShaderParam> m_uniforms;
-        QGLShader m_shader;  ///< Underlying shader
-        QByteArray m_source; ///< Non-mangled source code
-};
-
+#include "Shader.h"
+#include "ShaderParam.h"
 
 /// Wrapper around QGLShaderProgram providing parameter tweaking UI
 ///
@@ -188,4 +90,4 @@ class ShaderProgram : public QObject
 };
 
 
-#endif // SHADER_H_INCLUDED
+#endif // SHADER_PROGRAM_H_INCLUDED


### PR DESCRIPTION
* Moved the Shader, ShaderParam and ShaderProgram into their own compilations in src/shader
* Migrating to use C++17 std::variant for parameter values
* Extend ShaderProgram to get and set individual parameters by name

This is a precursor to supporting multi-pass rendering.  With optional `passes` parameter `View3D::drawPoints` knows how many times to draw the point cloud geometry, to implement transparency.