### PR TITLE
Fix PointSourceID Datatype

### DIFF
--- a/shaders/las_points.glsl
+++ b/shaders/las_points.glsl
@@ -29,7 +29,7 @@ in vec3 color;
 in float distance;
 in int returnNumber;
 in int numberOfReturns;
-in int pointSourceId;
+in mediump int pointSourceId;
 in int classification;
 //in float heightAboveGround;
 
@@ -76,10 +76,30 @@ void main()
         pointColor = vec3(0.2*returnNumber*exposure, 0.2*numberOfReturns*exposure, 0);
     else if (colorMode == 3)
     {
-        markerShape = (pointSourceId+1) % 5;
-        vec3 cols[] = vec3[](vec3(1,1,1), vec3(1,0,0), vec3(0,1,0), vec3(0,0,1),
-                             vec3(1,1,0), vec3(1,0,1), vec3(0,1,1));
-        pointColor = cols[(pointSourceId+3) % 7];
+        markerShape = int(mod(pointSourceId+1, 5));
+        vec3 cols[] = vec3[](
+            vec3(1, 1, 1),   // White
+            vec3(1, 0, 0),   // Red
+            vec3(0, 1, 0),   // Green
+            vec3(0, 0, 1),   // Blue
+            vec3(1, 1, 0),   // Yellow
+            vec3(1, 0, 1),   // Magenta
+            vec3(0, 1, 1),   // Cyan
+            vec3(0.5, 0.5, 0.5),   // Gray
+            vec3(0.3, 0.6, 0.9),   // Light Blue
+            vec3(0.8, 0.2, 0.5),   // Dark Pink
+            vec3(0.2, 0.8, 0.5),   // Light Green
+            vec3(0.7, 0.4, 0.1),   // Brown
+            vec3(0.9, 0.6, 0.2),   // Orange
+            vec3(0.5, 0.2, 0.7),   // Purple
+            vec3(0.2, 0.7, 0.4),   // Teal
+            vec3(0.8, 0.8, 0.2),   // Olive
+            vec3(0.4, 0.2, 0.8),   // Indigo
+            vec3(0.6, 0.9, 0.3),   // Lime
+            vec3(0.7, 0.2, 0.5),   // Raspberry
+            vec3(0.2, 0.5, 0.7)    // Sky Blue
+        );
+        pointColor = cols[int(mod(pointSourceId + 3, cols.length()))];
     }
     else if (colorMode == 4)
     {

--- a/shaders/las_points.glsl
+++ b/shaders/las_points.glsl
@@ -76,7 +76,7 @@ void main()
         pointColor = vec3(0.2*returnNumber*exposure, 0.2*numberOfReturns*exposure, 0);
     else if (colorMode == 3)
     {
-        markerShape = int(mod(pointSourceId+1, 5));
+        markerShape = (pointSourceId+1) % 5;
         vec3 cols[] = vec3[](
             vec3(1, 1, 1),   // White
             vec3(1, 0, 0),   // Red
@@ -99,7 +99,7 @@ void main()
             vec3(0.7, 0.2, 0.5),   // Raspberry
             vec3(0.2, 0.5, 0.7)    // Sky Blue
         );
-        pointColor = cols[int(mod(pointSourceId + 3, cols.length()))];
+        pointColor = cols[(pointSourceId + 3) % cols.length()];
     }
     else if (colorMode == 4)
     {

--- a/shaders/las_points.glsl
+++ b/shaders/las_points.glsl
@@ -29,7 +29,7 @@ in vec3 color;
 in float distance;
 in int returnNumber;
 in int numberOfReturns;
-in mediump int pointSourceId;
+in int pointSourceId;
 in int classification;
 //in float heightAboveGround;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -203,6 +203,13 @@ if(WIN32)
 endif()
 
 #------------------------------------------------------------------------------
+# Create a shader target to copy shaders at build-time
+add_custom_target(copy_shaders
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/shaders ${CMAKE_BINARY_DIR}/${DISPLAZ_SHADER_DIR}
+) 
+add_dependencies(displaz copy_shaders)
+
+#------------------------------------------------------------------------------
 # Experimental dvox utility
 if (DISPLAZ_BUILD_DVOX)
     add_executable(dvox

--- a/src/las_io.cpp
+++ b/src/las_io.cpp
@@ -218,7 +218,7 @@ bool PointArray::loadLas(QString fileName, size_t maxPointCount,
     fields.push_back(GeomField(TypeSpec::uint16_i(), "intensity", npoints));
     fields.push_back(GeomField(TypeSpec::uint8_i(), "returnNumber", npoints));
     fields.push_back(GeomField(TypeSpec::uint8_i(), "numberOfReturns", npoints));
-    fields.push_back(GeomField(TypeSpec::uint8_i(), "pointSourceId", npoints));
+    fields.push_back(GeomField(TypeSpec::uint16_i(), "pointSourceId", npoints));
     fields.push_back(GeomField(TypeSpec::uint8_i(), "classification", npoints));
     if (totalPoints == 0)
     {
@@ -230,7 +230,7 @@ bool PointArray::loadLas(QString fileName, size_t maxPointCount,
     uint16_t* intensity     = fields[1].as<uint16_t>();
     uint8_t* returnNumber   = fields[2].as<uint8_t>();
     uint8_t* numReturns     = fields[3].as<uint8_t>();
-    uint8_t* pointSourceId  = fields[4].as<uint8_t>();
+    uint16_t* pointSourceId  = fields[4].as<uint16_t>();
     uint8_t* classification = fields[5].as<uint8_t>();
     uint64_t readCount = 0;
     uint64_t nextDecimateBlock = 1;


### PR DESCRIPTION
1. The datatype of pointsourceid is incorrectly read from the LAZ file as uint8 rather than uint16, resulting in truncated values
2. The shader's % operator did not work well with the new uint16 value, so the mod function had to be used
3. With a greater range of pointsourceid's potential values, the list of 7 colors was not enough to visualize distinctly, so more colors were added.
4. When building the project, the shaders were not being copied into the build directory, preventing the executable from working when run through the build dir, so the shaders are now copied each time the project is built.