### PR TITLE
Enable Qt support for QT_SCALE_FACTOR

### DIFF
--- a/src/gui/guimain.cpp
+++ b/src/gui/guimain.cpp
@@ -66,6 +66,7 @@ int guimain(int argc, char* argv[])
     QCoreApplication::setApplicationVersion(DISPLAZ_VERSION_STRING);
     QCoreApplication::setOrganizationName("io.github.c42f");
     QCoreApplication::setOrganizationDomain("github.com/c42f/displaz");
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
     QApplication app(argc, argv);
 


### PR DESCRIPTION
Shrink the fonts for Linux 4K monitor via QT_SCALE_FACTOR=0.8