### PR TITLE
Update docker build coverage: Fedora 41 and 42 OK, Ubuntu 16.04 and 18.04 break

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,7 @@ Check the displaz builds and tests for a variety of Linux flavours.
 
 ## User Guide
 
-1. `docker build docker/ubuntu_18_04`
+1. `docker build --pull docker/ubuntu_20_04`
 2. `docker image prune -af`
 
 ## Options
@@ -17,8 +17,10 @@ Check the displaz builds and tests for a variety of Linux flavours.
 
 For example:
 
-`docker build docker/ubuntu_18_04 --build-arg MIRROR=http://au.archive.ubuntu.com/ubuntu/ `
+`docker build --pull docker/ubuntu_24_04 --build-arg MIRROR=http://au.archive.ubuntu.com/ubuntu/ `
 
 ## Notes
 
 * Ubuntu 12.04 Precise does not support C++11 required for displaz
+* Ubuntu 16.04 Xenial has Qt 5.5.1 - not working
+* Ubuntu 18.04 Bionic has Qt 5.9.5 - not working

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,7 @@ Check the displaz builds and tests for a variety of Linux flavours.
 
 ## User Guide
 
-1. `docker build --pull docker/ubuntu_20_04`
+1. `docker build --pull docker/ubuntu_24_04`
 2. `docker image prune -af`
 
 ## Options

--- a/docker/debian_bookworm/Dockerfile
+++ b/docker/debian_bookworm/Dockerfile
@@ -1,6 +1,8 @@
 # Minimal displaz Qt5 build, test and install
 # using Docker Debian 12 (bookworm)
 
+# Status: Confirmed working April 20th 2025
+
 FROM debian:bookworm
 MAINTAINER Nigel Stewart (nigels@nigels.com)
 

--- a/docker/debian_bullseye/Dockerfile
+++ b/docker/debian_bullseye/Dockerfile
@@ -1,6 +1,8 @@
 # Minimal displaz Qt5 build, test and install
 # using Docker Debian 11 (bullseye)
 
+# Status: Confirmed working April 20th 2025
+
 FROM debian:bullseye
 MAINTAINER Nigel Stewart (nigels@nigels.com)
 

--- a/docker/debian_buster/Dockerfile
+++ b/docker/debian_buster/Dockerfile
@@ -1,6 +1,8 @@
 # Minimal displaz Qt5 build, test and install
 # using Docker Debian 10 (buster)
 
+# Status: Confirmed working April 20th 2025
+
 FROM debian:buster
 MAINTAINER Nigel Stewart (nigels@nigels.com)
 

--- a/docker/fedora_33/Dockerfile
+++ b/docker/fedora_33/Dockerfile
@@ -1,6 +1,10 @@
 # Minimal displaz Qt5 build, test and install
 # using Fedora 33
 
+# Fedora 33 EOL: 2021-11-30
+
+# Status: Confirmed working April 20th 2025
+
 FROM fedora:33
 MAINTAINER Nigel Stewart (nigels@nigels.com)
 

--- a/docker/fedora_34/Dockerfile
+++ b/docker/fedora_34/Dockerfile
@@ -1,6 +1,10 @@
 # Minimal displaz Qt5 build, test and install
 # using Fedora 34
 
+# Fedora 34 EOL: 2022-06-07
+
+# Status: Confirmed working April 20th 2025
+
 FROM fedora:34
 MAINTAINER Nigel Stewart (nigels@nigels.com)
 

--- a/docker/fedora_35/Dockerfile
+++ b/docker/fedora_35/Dockerfile
@@ -1,6 +1,10 @@
 # Minimal displaz Qt5 build, test and install
 # using Fedora 35
 
+# Fedora 35 EOL: 2022-12-13
+
+# Status: Confirmed working April 20th 2025
+
 FROM fedora:35
 MAINTAINER Nigel Stewart (nigels@nigels.com)
 
@@ -12,7 +16,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN dnf -y upgrade
 
-RUN dnf -y install git gcc-c++ make patch cmake qt5-qtbase-devel mesa-libGLU-devel python-docutils
+RUN dnf -y install git gcc-c++ make patch cmake qt5-qtbase-devel mesa-libGLU-devel python-docutils findutils
 
 #
 # Clone repo

--- a/docker/fedora_36/Dockerfile
+++ b/docker/fedora_36/Dockerfile
@@ -1,6 +1,10 @@
 # Minimal displaz Qt5 build, test and install
 # using Fedora 36
 
+# Fedora 36 EOL: 2023-05-16
+
+# Status: Confirmed working April 20th 2025
+
 FROM fedora:36
 MAINTAINER Nigel Stewart (nigels@nigels.com)
 

--- a/docker/fedora_37/Dockerfile
+++ b/docker/fedora_37/Dockerfile
@@ -1,6 +1,10 @@
 # Minimal displaz Qt5 build, test and install
 # using Fedora 37
 
+# Fedora 37 EOL: 2023-12-05
+
+# Status: Confirmed working April 20th 2025
+
 FROM fedora:37
 MAINTAINER Nigel Stewart (nigels@nigels.com)
 

--- a/docker/fedora_38/Dockerfile
+++ b/docker/fedora_38/Dockerfile
@@ -1,6 +1,8 @@
 # Minimal displaz Qt5 build, test and install
 # using Fedora 38
 
+# Fedora 38 EOL: 2024-05-21
+
 FROM fedora:38
 MAINTAINER Nigel Stewart (nigels@nigels.com)
 

--- a/docker/fedora_39/Dockerfile
+++ b/docker/fedora_39/Dockerfile
@@ -1,6 +1,8 @@
 # Minimal displaz Qt5 build, test and install
 # using Fedora 39
 
+# Fedora 39 EOL: 2024-11-26
+
 FROM fedora:39
 MAINTAINER Nigel Stewart (nigels@nigels.com)
 

--- a/docker/fedora_40/Dockerfile
+++ b/docker/fedora_40/Dockerfile
@@ -1,6 +1,8 @@
 # Minimal displaz Qt5 build, test and install
 # using Fedora 40
 
+# Status: Confirmed working April 20th 2025
+
 FROM fedora:40
 MAINTAINER Nigel Stewart (nigels@nigels.com)
 

--- a/docker/fedora_41/Dockerfile
+++ b/docker/fedora_41/Dockerfile
@@ -1,25 +1,10 @@
 # Minimal displaz Qt5 build, test and install
-# using Docker Ubuntu 24.04 (Noble)
+# using Fedora 41
 
 # Status: Confirmed working April 20th 2025
 
-FROM ubuntu:noble
+FROM fedora:41
 MAINTAINER Nigel Stewart (nigels@nigels.com)
-
-#
-# Optional custom package mirror
-#
-# --build-arg MIRROR=http://au.archive.ubuntu.com/ubuntu/
-#
-
-ARG MIRROR
-ENV MIRROR ${MIRROR:-http://archive.ubuntu.com/ubuntu}
-
-#RUN sed -i -r "/#.*/d"                                           /etc/apt/sources.list
-#RUN sed -i -r "/^$/d"                                            /etc/apt/sources.list
-#RUN cat /etc/apt/sources.list
-#RUN sed -i -r "s#deb .* noble(-.*)? #deb ${MIRROR} noble\\1 #"   /etc/apt/sources.list
-#RUN cat /etc/apt/sources.list
 
 #
 # Update and install build tools, dependencies
@@ -27,11 +12,9 @@ ENV MIRROR ${MIRROR:-http://archive.ubuntu.com/ubuntu}
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt update
-RUN apt dist-upgrade -y
+RUN dnf -y upgrade
 
-RUN apt install -y build-essential git cmake doxygen graphviz cppcheck
-RUN apt install -y g++ cmake qtbase5-dev python3
+RUN dnf -y install git gcc-c++ make patch cmake qt5-qtbase-devel mesa-libGLU-devel python-docutils
 
 #
 # Clone repo

--- a/docker/fedora_42/Dockerfile
+++ b/docker/fedora_42/Dockerfile
@@ -1,25 +1,10 @@
 # Minimal displaz Qt5 build, test and install
-# using Docker Ubuntu 24.04 (Noble)
+# using Fedora 42
 
 # Status: Confirmed working April 20th 2025
 
-FROM ubuntu:noble
+FROM fedora:42
 MAINTAINER Nigel Stewart (nigels@nigels.com)
-
-#
-# Optional custom package mirror
-#
-# --build-arg MIRROR=http://au.archive.ubuntu.com/ubuntu/
-#
-
-ARG MIRROR
-ENV MIRROR ${MIRROR:-http://archive.ubuntu.com/ubuntu}
-
-#RUN sed -i -r "/#.*/d"                                           /etc/apt/sources.list
-#RUN sed -i -r "/^$/d"                                            /etc/apt/sources.list
-#RUN cat /etc/apt/sources.list
-#RUN sed -i -r "s#deb .* noble(-.*)? #deb ${MIRROR} noble\\1 #"   /etc/apt/sources.list
-#RUN cat /etc/apt/sources.list
 
 #
 # Update and install build tools, dependencies
@@ -27,11 +12,9 @@ ENV MIRROR ${MIRROR:-http://archive.ubuntu.com/ubuntu}
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt update
-RUN apt dist-upgrade -y
+RUN dnf -y upgrade
 
-RUN apt install -y build-essential git cmake doxygen graphviz cppcheck
-RUN apt install -y g++ cmake qtbase5-dev python3
+RUN dnf -y install git gcc-c++ make patch cmake qt5-qtbase-devel mesa-libGLU-devel python-docutils
 
 #
 # Clone repo

--- a/docker/ubuntu_16_04/Dockerfile
+++ b/docker/ubuntu_16_04/Dockerfile
@@ -1,6 +1,9 @@
 # Minimal displaz Qt5 build, test and install
 # using Docker Ubuntu 16.04 (Xenial)
 
+# Status: Not working April 20th 2025
+#         QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
 FROM ubuntu:xenial
 MAINTAINER Nigel Stewart (nigels@nigels.com)
 

--- a/docker/ubuntu_18_04/Dockerfile
+++ b/docker/ubuntu_18_04/Dockerfile
@@ -1,6 +1,9 @@
 # Minimal displaz Qt5 build, test and install
 # using Docker Ubuntu 18.04 (Bionic)
 
+# Status: Not working April 20th 2025
+#         error: 'class QFontMetrics' has no member named 'horizontalAdvance'
+
 FROM ubuntu:bionic
 MAINTAINER Nigel Stewart (nigels@nigels.com)
 

--- a/docker/ubuntu_20_04/Dockerfile
+++ b/docker/ubuntu_20_04/Dockerfile
@@ -1,6 +1,8 @@
 # Minimal displaz Qt5 build, test and install
 # using Docker Ubuntu 20.04 (Focal)
 
+# Status: Confirmed working April 20th 2025
+
 FROM ubuntu:focal
 MAINTAINER Nigel Stewart (nigels@nigels.com)
 

--- a/docker/ubuntu_22_04/Dockerfile
+++ b/docker/ubuntu_22_04/Dockerfile
@@ -1,6 +1,8 @@
 # Minimal displaz Qt5 build, test and install
 # using Docker Ubuntu 22.04 (Jammy)
 
+# Status: Confirmed working April 20th 2025
+
 FROM ubuntu:jammy
 MAINTAINER Nigel Stewart (nigels@nigels.com)
 


### PR DESCRIPTION
Ubuntu 16.04 and 16.04 are Qt5, but an earlier one.